### PR TITLE
fix: remove duplicate PR-closed trigger and fix README badge

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,6 @@ name: E2E Tests
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-    types: [closed]
   schedule:
     # Run nightly at 2 AM UTC
     - cron: '0 2 * * *'
@@ -29,12 +26,6 @@ jobs:
   e2e-tests:
     name: Docker E2E Tests
     runs-on: ubuntu-latest
-    # Only run on merged PRs, not all closed PRs
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
 
     timeout-minutes: 30
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/edTheGuy00/fdemon/releases">
         <img src="https://img.shields.io/github/v/release/edTheGuy00/fdemon?style=flat&labelColor=1d1d1d&color=54c5f8&logo=GitHub&logoColor=white" alt="GitHub Release"></a>
     <a href="https://github.com/edTheGuy00/fdemon/actions">
-        <img src="https://img.shields.io/github/actions/workflow/status/edTheGuy00/fdemon/ci.yml?style=flat&labelColor=1d1d1d&color=white&logo=GitHub%20Actions&logoColor=white" alt="CI"></a>
+        <img src="https://img.shields.io/github/actions/workflow/status/edTheGuy00/fdemon/e2e.yml?style=flat&labelColor=1d1d1d&color=white&logo=GitHub%20Actions&logoColor=white" alt="E2E Tests"></a>
     <a href="https://github.com/edTheGuy00/fdemon/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/license-BSL%201.1-white?style=flat&labelColor=1d1d1d" alt="License"></a>
     <br>


### PR DESCRIPTION
The e2e workflow triggered on both `push` to main and `pull_request: closed`, causing duplicate runs that cancelled each other on every PR merge. The push trigger already covers merges, so the pull_request trigger was redundant.

Also fix the README status badge pointing to nonexistent `ci.yml` — changed to `e2e.yml` to match the actual workflow file.