### PR TITLE
fix(new-session): drop device-cache TTL, refresh in background

### DIFF
--- a/crates/fdemon-app/src/actions/mod.rs
+++ b/crates/fdemon-app/src/actions/mod.rs
@@ -89,6 +89,14 @@ pub fn handle_action(
             spawn::spawn_bootable_device_discovery(msg_tx, tool_availability);
         }
 
+        UpdateAction::DiscoverDevicesAndBootable { flutter } => {
+            // Foreground connected discovery (loading-aware, shows spinner and surfaces errors).
+            spawn::spawn_device_discovery(msg_tx.clone(), flutter);
+            // Background bootable discovery in parallel (uses tool_availability for
+            // emulator/simulator listings; errors are logged only).
+            spawn::spawn_bootable_device_discovery(msg_tx, tool_availability);
+        }
+
         UpdateAction::DiscoverDevicesAndAutoLaunch { configs, flutter } => {
             spawn::spawn_auto_launch(msg_tx, configs, project_path.to_path_buf(), flutter);
         }

--- a/crates/fdemon-app/src/actions/mod.rs
+++ b/crates/fdemon-app/src/actions/mod.rs
@@ -82,6 +82,13 @@ pub fn handle_action(
             spawn::spawn_device_discovery_background(msg_tx, flutter);
         }
 
+        UpdateAction::RefreshDevicesAndBootableBackground { flutter } => {
+            // Connected device refresh — errors logged only (UI shows cached list).
+            spawn::spawn_device_discovery_background(msg_tx.clone(), flutter);
+            // Bootable refresh — errors logged only.
+            spawn::spawn_bootable_device_discovery(msg_tx, tool_availability);
+        }
+
         UpdateAction::DiscoverDevicesAndAutoLaunch { configs, flutter } => {
             spawn::spawn_auto_launch(msg_tx, configs, project_path.to_path_buf(), flutter);
         }

--- a/crates/fdemon-app/src/handler/mod.rs
+++ b/crates/fdemon-app/src/handler/mod.rs
@@ -79,6 +79,18 @@ pub enum UpdateAction {
     /// previous device lists until the discovery returns.
     RefreshDevicesAndBootableBackground { flutter: FlutterExecutable },
 
+    /// Foreground connected-device discovery + background bootable discovery in parallel.
+    /// Used by the new-session dialog cache-miss fallback so both tabs populate on
+    /// first dialog open even when no caches exist.
+    ///
+    /// `UpdateResult` carries a single action, so this combined variant is the cleanest
+    /// way to spawn both. Mirrors `RefreshDevicesAndBootableBackground` but uses the
+    /// foreground (loading-aware) connected spawn.
+    DiscoverDevicesAndBootable {
+        /// Flutter executable to use for both discovery tasks.
+        flutter: FlutterExecutable,
+    },
+
     /// Discover devices and auto-launch a session
     /// Used when auto_start=true to run device discovery in background
     /// and automatically launch with the best available config/device

--- a/crates/fdemon-app/src/handler/mod.rs
+++ b/crates/fdemon-app/src/handler/mod.rs
@@ -77,7 +77,10 @@ pub enum UpdateAction {
     /// shown, so that both lists are kept fresh without a loading screen.
     /// Errors on either side are logged only; the user keeps seeing the
     /// previous device lists until the discovery returns.
-    RefreshDevicesAndBootableBackground { flutter: FlutterExecutable },
+    RefreshDevicesAndBootableBackground {
+        /// Flutter executable to use for both background discovery tasks.
+        flutter: FlutterExecutable,
+    },
 
     /// Foreground connected-device discovery + background bootable discovery in parallel.
     /// Used by the new-session dialog cache-miss fallback so both tabs populate on

--- a/crates/fdemon-app/src/handler/mod.rs
+++ b/crates/fdemon-app/src/handler/mod.rs
@@ -71,6 +71,14 @@ pub enum UpdateAction {
         flutter: FlutterExecutable,
     },
 
+    /// Refresh both connected and bootable device lists in the background.
+    ///
+    /// Dispatched when the new-session dialog opens with cached data already
+    /// shown, so that both lists are kept fresh without a loading screen.
+    /// Errors on either side are logged only; the user keeps seeing the
+    /// previous device lists until the discovery returns.
+    RefreshDevicesAndBootableBackground { flutter: FlutterExecutable },
+
     /// Discover devices and auto-launch a session
     /// Used when auto_start=true to run device discovery in background
     /// and automatically launch with the best available config/device

--- a/crates/fdemon-app/src/handler/new_session/navigation.rs
+++ b/crates/fdemon-app/src/handler/new_session/navigation.rs
@@ -219,6 +219,8 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
 
     // Check bootable devices cache (independent of connected devices cache)
     let bootable_cached = if let Some((simulators, avds)) = state.get_cached_bootable_devices() {
+        let simulators = simulators.clone();
+        let avds = avds.clone();
         tracing::debug!(
             "Using cached bootable devices ({} simulators, {} AVDs, age: {:?})",
             simulators.len(),

--- a/crates/fdemon-app/src/handler/new_session/navigation.rs
+++ b/crates/fdemon-app/src/handler/new_session/navigation.rs
@@ -373,20 +373,30 @@ mod tests {
     }
 
     #[test]
-    fn test_open_dialog_expired_cache_shows_loading() {
+    fn test_open_dialog_stale_timestamp_cache_still_shows_devices() {
         let mut state = test_app_state();
 
-        // Set cache with old timestamp (> 30s ago)
+        // Set cache with old timestamp (> 30s ago) — cache no longer expires,
+        // so devices should still be shown immediately with a background refresh.
         state.device_cache = Some(vec![test_device_full("1", "iPhone", "ios", false)]);
         state.devices_last_updated = Some(Instant::now() - Duration::from_secs(60));
 
         let result = handle_open_new_session_dialog(&mut state);
 
-        // Cache expired - should show loading
-        assert!(state.new_session_dialog_state.target_selector.loading);
+        // Cache is still valid — should show device immediately, not loading
+        assert!(!state.new_session_dialog_state.target_selector.loading);
+        assert_eq!(
+            state
+                .new_session_dialog_state
+                .target_selector
+                .connected_devices
+                .len(),
+            1
+        );
+        // Should trigger background refresh (not foreground discovery)
         assert!(matches!(
             result.action,
-            Some(UpdateAction::DiscoverDevices { .. })
+            Some(UpdateAction::RefreshDevicesBackground { .. })
         ));
     }
 

--- a/crates/fdemon-app/src/handler/new_session/navigation.rs
+++ b/crates/fdemon-app/src/handler/new_session/navigation.rs
@@ -202,10 +202,12 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
 
     // Check connected devices cache
     let connected_cached = if let Some(cached_devices) = state.get_cached_devices() {
+        let cached_len = cached_devices.len();
+        let age = state.devices_last_updated.map(|t| t.elapsed());
         tracing::debug!(
             "Using cached devices ({} devices, age: {:?})",
-            cached_devices.len(),
-            state.devices_last_updated.map(|t| t.elapsed())
+            cached_len,
+            age
         );
 
         // Populate dialog with cached devices immediately
@@ -245,7 +247,13 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
 
     if connected_cached || bootable_cached {
         // We have at least one cached list shown — refresh in the background.
-        // Set refreshing flags AFTER set_*_devices() so they are not cleared.
+        // Set refreshing flags AFTER set_*_devices() (which clears them).
+        //
+        // Race: if the user closes and quickly reopens the dialog while a previous
+        // background discovery is in flight, that discovery's DevicesDiscovered message
+        // will arrive at the new dialog and clear `refreshing` before this open's own
+        // discovery completes. Convergence is correct (last write wins), but the visual
+        // cue may briefly disappear and reappear. Acceptable transient flicker.
         if connected_cached {
             state.new_session_dialog_state.target_selector.refreshing = true;
         }
@@ -266,21 +274,10 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
     UpdateResult::action(UpdateAction::DiscoverDevicesAndBootable { flutter })
 }
 
-/// Closes the new session dialog and returns to the appropriate UI mode.
-///
-/// If sessions are running, returns to Normal mode. Otherwise, remains
-/// in Normal mode (as startup state).
+/// Closes the new session dialog and returns to Normal UI mode.
 pub fn handle_close_new_session_dialog(state: &mut AppState) -> UpdateResult {
     state.hide_new_session_dialog();
-
-    // Return to appropriate UI mode based on session state
-    if state.session_manager.has_running_sessions() {
-        state.ui_mode = UiMode::Normal;
-    } else {
-        // No sessions, stay in startup mode
-        state.ui_mode = UiMode::Normal;
-    }
-
+    state.ui_mode = UiMode::Normal;
     UpdateResult::none()
 }
 

--- a/crates/fdemon-app/src/handler/new_session/navigation.rs
+++ b/crates/fdemon-app/src/handler/new_session/navigation.rs
@@ -186,7 +186,8 @@ pub fn handle_field_activate(
 /// the corresponding `refreshing` flag is set on the target selector and
 /// `RefreshDevicesAndBootableBackground` is dispatched so both lists stay
 /// fresh without a loading screen. If both caches are empty (first ever
-/// open), falls back to the foreground `DiscoverDevices` path.
+/// open), falls back to the foreground `DiscoverDevicesAndBootable` path so
+/// both the Connected and Bootable tabs populate on the first dialog open.
 pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
     // Load configs with error handling
     let configs = crate::config::load_all_configs(&state.project_path);
@@ -258,9 +259,11 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
     }
 
     // Both caches are empty — fall back to the foreground discovery path.
-    tracing::debug!("Device cache miss, triggering foreground discovery");
+    // Also trigger bootable discovery in parallel so the Bootable tab populates
+    // on the first dialog open without requiring a manual tab switch.
+    tracing::debug!("Device cache miss, triggering combined foreground+bootable discovery");
     state.new_session_dialog_state.target_selector.loading = true;
-    UpdateResult::action(UpdateAction::DiscoverDevices { flutter })
+    UpdateResult::action(UpdateAction::DiscoverDevicesAndBootable { flutter })
 }
 
 /// Closes the new session dialog and returns to the appropriate UI mode.
@@ -381,10 +384,10 @@ mod tests {
         // Should show loading
         assert!(state.new_session_dialog_state.target_selector.loading);
 
-        // Should trigger foreground discovery
+        // Should trigger combined foreground+bootable discovery (updated from DiscoverDevices)
         assert!(matches!(
             result.action,
-            Some(UpdateAction::DiscoverDevices { .. })
+            Some(UpdateAction::DiscoverDevicesAndBootable { .. })
         ));
     }
 
@@ -648,8 +651,32 @@ mod tests {
         assert!(!state.new_session_dialog_state.target_selector.refreshing);
         assert!(matches!(
             result.action,
-            Some(UpdateAction::DiscoverDevices { .. })
+            Some(UpdateAction::DiscoverDevicesAndBootable { .. })
         ));
+    }
+
+    #[test]
+    fn test_open_dialog_no_caches_dispatches_combined_discovery() {
+        let mut state = test_app_state();
+        // Both caches empty (default state)
+        assert!(state.device_cache.is_none());
+        assert!(state.ios_simulators_cache.is_none());
+        assert!(state.android_avds_cache.is_none());
+
+        let result = handle_open_new_session_dialog(&mut state);
+
+        assert!(
+            state.new_session_dialog_state.target_selector.loading,
+            "connected tab should show loading on cache miss"
+        );
+        assert!(
+            matches!(
+                result.action,
+                Some(UpdateAction::DiscoverDevicesAndBootable { .. })
+            ),
+            "cache miss should dispatch combined discovery, got {:?}",
+            result.action
+        );
     }
 
     #[test]

--- a/crates/fdemon-app/src/handler/new_session/navigation.rs
+++ b/crates/fdemon-app/src/handler/new_session/navigation.rs
@@ -241,22 +241,33 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
     };
 
     let Some(flutter) = state.flutter_executable() else {
-        tracing::warn!("handle_open_new_session_dialog: no Flutter SDK — skipping device refresh");
+        tracing::warn!(
+            "handle_open_new_session_dialog: no Flutter SDK — surfacing error to dialog"
+        );
+        let selector = &mut state.new_session_dialog_state.target_selector;
+        // set_error() clears `loading` and `refreshing`; bootable flags must be
+        // cleared explicitly because bootable discovery is independent of the
+        // Flutter SDK (see task 02 for the doc rewrite explaining this).
+        selector.bootable_loading = false;
+        selector.bootable_refreshing = false;
+        selector.set_error(
+            "No Flutter SDK found. Configure sdk_path in .fdemon/config.toml or install Flutter."
+                .to_string(),
+        );
         return UpdateResult::none();
     };
 
-    if connected_cached || bootable_cached {
-        // We have at least one cached list shown — refresh in the background.
-        // Set refreshing flags AFTER set_*_devices() (which clears them).
+    if connected_cached {
+        // Connected list shown — refresh both in background. Failures on the
+        // connected side will only clear `refreshing` (not `loading`), but that's
+        // fine because `loading` is already false (set_connected_devices cleared it).
         //
         // Race: if the user closes and quickly reopens the dialog while a previous
         // background discovery is in flight, that discovery's DevicesDiscovered message
         // will arrive at the new dialog and clear `refreshing` before this open's own
         // discovery completes. Convergence is correct (last write wins), but the visual
         // cue may briefly disappear and reappear. Acceptable transient flicker.
-        if connected_cached {
-            state.new_session_dialog_state.target_selector.refreshing = true;
-        }
+        state.new_session_dialog_state.target_selector.refreshing = true;
         if bootable_cached {
             state
                 .new_session_dialog_state
@@ -266,11 +277,26 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
         return UpdateResult::action(UpdateAction::RefreshDevicesAndBootableBackground { flutter });
     }
 
-    // Both caches are empty — fall back to the foreground discovery path.
-    // Also trigger bootable discovery in parallel so the Bootable tab populates
-    // on the first dialog open without requiring a manual tab switch.
-    tracing::debug!("Device cache miss, triggering combined foreground+bootable discovery");
+    // Connected cache missing — foreground discovery so failures route through
+    // set_error() and clear `loading`. Bootable spawns in parallel (background).
+    if bootable_cached {
+        // Bootable already shown; mark its parallel refresh as in-flight.
+        state
+            .new_session_dialog_state
+            .target_selector
+            .bootable_refreshing = true;
+    }
+    // `loading` is already true (default from show_new_session_dialog), but set
+    // explicitly for readability and to defend against future refactors.
     state.new_session_dialog_state.target_selector.loading = true;
+    tracing::debug!(
+        "Device cache miss for connected ({}), triggering foreground combined discovery",
+        if bootable_cached {
+            "bootable cached"
+        } else {
+            "neither cached"
+        }
+    );
     UpdateResult::action(UpdateAction::DiscoverDevicesAndBootable { flutter })
 }
 
@@ -712,5 +738,104 @@ mod tests {
                 .bootable_loading
         );
         assert!(result.action.is_none());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // F1 + F2 regression tests (PR #37 Copilot review)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_open_dialog_no_flutter_sdk_surfaces_error() {
+        let mut state = test_app_state();
+        // Remove the injected SDK so flutter_executable() returns None.
+        state.resolved_sdk = None;
+
+        let result = handle_open_new_session_dialog(&mut state);
+
+        let selector = &state.new_session_dialog_state.target_selector;
+        assert_eq!(
+            selector.error,
+            Some(
+                "No Flutter SDK found. Configure sdk_path in .fdemon/config.toml or install Flutter."
+                    .to_string()
+            ),
+            "dialog must surface the SDK-missing error"
+        );
+        assert!(!selector.loading, "loading must be cleared by set_error()");
+        assert!(
+            !selector.bootable_loading,
+            "bootable_loading must be explicitly cleared"
+        );
+        assert!(
+            !selector.refreshing,
+            "refreshing must be cleared by set_error()"
+        );
+        assert!(
+            !selector.bootable_refreshing,
+            "bootable_refreshing must be explicitly cleared"
+        );
+        assert!(
+            result.action.is_none(),
+            "no action should be dispatched when SDK is missing"
+        );
+    }
+
+    #[test]
+    fn test_open_dialog_bootable_cached_only_uses_foreground() {
+        let mut state = test_app_state();
+        // Populate only the bootable cache; leave connected cache empty.
+        state.set_bootable_cache(vec![], vec![]);
+
+        let result = handle_open_new_session_dialog(&mut state);
+
+        let selector = &state.new_session_dialog_state.target_selector;
+        // Must use the foreground path (not background), because the connected
+        // cache is missing and failures on the foreground path clear `loading`.
+        assert!(
+            matches!(
+                result.action,
+                Some(UpdateAction::DiscoverDevicesAndBootable { .. })
+            ),
+            "bootable-only cache must dispatch DiscoverDevicesAndBootable, got {:?}",
+            result.action
+        );
+        assert!(selector.loading, "connected tab must show loading spinner");
+        assert!(
+            selector.bootable_refreshing,
+            "bootable is already shown — its in-flight flag must be set"
+        );
+        assert!(
+            !selector.refreshing,
+            "connected isn't cached — refreshing (not loading) must NOT be set"
+        );
+    }
+
+    #[test]
+    fn test_open_dialog_both_cached_uses_background() {
+        let mut state = test_app_state();
+        // Populate both caches.
+        state.set_device_cache(vec![test_device_full("1", "iPhone", "ios", false)]);
+        state.set_bootable_cache(vec![], vec![]);
+
+        let result = handle_open_new_session_dialog(&mut state);
+
+        let selector = &state.new_session_dialog_state.target_selector;
+        assert!(
+            matches!(
+                result.action,
+                Some(UpdateAction::RefreshDevicesAndBootableBackground { .. })
+            ),
+            "both caches populated must dispatch background refresh, got {:?}",
+            result.action
+        );
+        assert!(
+            selector.refreshing,
+            "connected cache hit must set refreshing"
+        );
+        assert!(
+            selector.bootable_refreshing,
+            "bootable cache hit must set bootable_refreshing"
+        );
+        assert!(!selector.loading, "loading must NOT be set on cache hit");
     }
 }

--- a/crates/fdemon-app/src/handler/new_session/navigation.rs
+++ b/crates/fdemon-app/src/handler/new_session/navigation.rs
@@ -179,10 +179,14 @@ pub fn handle_field_activate(
 /// Opens the new session dialog and triggers device discovery.
 ///
 /// Loads launch configurations from the project path and initializes
-/// the dialog state. If no configurations are found, defaults are used.
+/// the dialog state.
 ///
-/// Uses cached devices if available (< 30s old) for instant display,
-/// then triggers background refresh to keep data fresh.
+/// Uses any cached devices/bootable for instant display. The cache has no TTL;
+/// it survives for the lifetime of the AppState. Whenever a cache hit occurs,
+/// the corresponding `refreshing` flag is set on the target selector and
+/// `RefreshDevicesAndBootableBackground` is dispatched so both lists stay
+/// fresh without a loading screen. If both caches are empty (first ever
+/// open), falls back to the foreground `DiscoverDevices` path.
 pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
     // Load configs with error handling
     let configs = crate::config::load_all_configs(&state.project_path);
@@ -195,11 +199,8 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
     // Show the dialog
     state.show_new_session_dialog(configs);
 
-    // Check cache first - this is the ONLY place where cache is checked and populated
-    // to avoid duplicate logic. The handler manages both cache checking and background refresh.
-
     // Check connected devices cache
-    let has_connected_cache = if let Some(cached_devices) = state.get_cached_devices() {
+    let connected_cached = if let Some(cached_devices) = state.get_cached_devices() {
         tracing::debug!(
             "Using cached devices ({} devices, age: {:?})",
             cached_devices.len(),
@@ -217,7 +218,7 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
     };
 
     // Check bootable devices cache (independent of connected devices cache)
-    if let Some((simulators, avds)) = state.get_cached_bootable_devices() {
+    let bootable_cached = if let Some((simulators, avds)) = state.get_cached_bootable_devices() {
         tracing::debug!(
             "Using cached bootable devices ({} simulators, {} AVDs, age: {:?})",
             simulators.len(),
@@ -229,23 +230,33 @@ pub fn handle_open_new_session_dialog(state: &mut AppState) -> UpdateResult {
             .new_session_dialog_state
             .target_selector
             .set_bootable_devices(simulators, avds);
-    }
+        true
+    } else {
+        false
+    };
 
-    // If we have connected device cache, trigger background refresh
-    if has_connected_cache {
-        let Some(flutter) = state.flutter_executable() else {
-            tracing::warn!("handle_open_new_session_dialog: no Flutter SDK — skipping background device refresh");
-            return UpdateResult::none();
-        };
-        return UpdateResult::action(UpdateAction::RefreshDevicesBackground { flutter });
-    }
-
-    // Cache miss or expired - show loading and discover
-    tracing::debug!("Device cache miss, triggering discovery");
     let Some(flutter) = state.flutter_executable() else {
-        tracing::warn!("handle_open_new_session_dialog: no Flutter SDK — cannot discover devices");
+        tracing::warn!("handle_open_new_session_dialog: no Flutter SDK — skipping device refresh");
         return UpdateResult::none();
     };
+
+    if connected_cached || bootable_cached {
+        // We have at least one cached list shown — refresh in the background.
+        // Set refreshing flags AFTER set_*_devices() so they are not cleared.
+        if connected_cached {
+            state.new_session_dialog_state.target_selector.refreshing = true;
+        }
+        if bootable_cached {
+            state
+                .new_session_dialog_state
+                .target_selector
+                .bootable_refreshing = true;
+        }
+        return UpdateResult::action(UpdateAction::RefreshDevicesAndBootableBackground { flutter });
+    }
+
+    // Both caches are empty — fall back to the foreground discovery path.
+    tracing::debug!("Device cache miss, triggering foreground discovery");
     state.new_session_dialog_state.target_selector.loading = true;
     UpdateResult::action(UpdateAction::DiscoverDevices { flutter })
 }
@@ -348,10 +359,13 @@ mod tests {
         // Should NOT show loading
         assert!(!state.new_session_dialog_state.target_selector.loading);
 
-        // Should trigger background refresh
+        // refreshing should be set because we had a cache hit
+        assert!(state.new_session_dialog_state.target_selector.refreshing);
+
+        // Should trigger background refresh (combined action)
         assert!(matches!(
             result.action,
-            Some(UpdateAction::RefreshDevicesBackground { .. })
+            Some(UpdateAction::RefreshDevicesAndBootableBackground { .. })
         ));
     }
 
@@ -393,10 +407,12 @@ mod tests {
                 .len(),
             1
         );
-        // Should trigger background refresh (not foreground discovery)
+        // refreshing should be set because we had a cache hit
+        assert!(state.new_session_dialog_state.target_selector.refreshing);
+        // Should trigger combined background refresh (not foreground discovery)
         assert!(matches!(
             result.action,
-            Some(UpdateAction::RefreshDevicesBackground { .. })
+            Some(UpdateAction::RefreshDevicesAndBootableBackground { .. })
         ));
     }
 
@@ -579,6 +595,58 @@ mod tests {
         assert!(matches!(
             result.action,
             Some(UpdateAction::DiscoverBootableDevices)
+        ));
+    }
+
+    #[test]
+    fn test_open_dialog_sets_refreshing_flags_on_cache_hit() {
+        let mut state = test_app_state();
+
+        // Pre-populate both caches.
+        state.set_device_cache(vec![test_device_full("1", "iPhone", "ios", false)]);
+        state.set_bootable_cache(vec![], vec![]);
+
+        let result = handle_open_new_session_dialog(&mut state);
+
+        assert!(state.new_session_dialog_state.target_selector.refreshing);
+        assert!(
+            state
+                .new_session_dialog_state
+                .target_selector
+                .bootable_refreshing
+        );
+        assert!(matches!(
+            result.action,
+            Some(UpdateAction::RefreshDevicesAndBootableBackground { .. })
+        ));
+    }
+
+    #[test]
+    fn test_open_dialog_only_connected_cached_sets_only_refreshing() {
+        let mut state = test_app_state();
+        state.set_device_cache(vec![test_device_full("1", "iPhone", "ios", false)]);
+        // No bootable cache set.
+
+        let _ = handle_open_new_session_dialog(&mut state);
+        assert!(state.new_session_dialog_state.target_selector.refreshing);
+        assert!(
+            !state
+                .new_session_dialog_state
+                .target_selector
+                .bootable_refreshing
+        );
+    }
+
+    #[test]
+    fn test_open_dialog_no_caches_falls_back_to_loading() {
+        let mut state = test_app_state();
+        // No caches set.
+        let result = handle_open_new_session_dialog(&mut state);
+        assert!(state.new_session_dialog_state.target_selector.loading);
+        assert!(!state.new_session_dialog_state.target_selector.refreshing);
+        assert!(matches!(
+            result.action,
+            Some(UpdateAction::DiscoverDevices { .. })
         ));
     }
 

--- a/crates/fdemon-app/src/handler/tests.rs
+++ b/crates/fdemon-app/src/handler/tests.rs
@@ -10085,6 +10085,32 @@ fn test_devices_discovered_clears_refreshing() {
 }
 
 #[test]
+fn test_bootable_devices_discovered_clears_bootable_refreshing() {
+    let mut state = AppState::new();
+    state.show_new_session_dialog(crate::config::LoadedConfigs::default());
+    state
+        .new_session_dialog_state
+        .target_selector
+        .bootable_refreshing = true;
+
+    let _ = update(
+        &mut state,
+        Message::BootableDevicesDiscovered {
+            ios_simulators: vec![],
+            android_avds: vec![],
+        },
+    );
+
+    assert!(
+        !state
+            .new_session_dialog_state
+            .target_selector
+            .bootable_refreshing,
+        "BootableDevicesDiscovered must clear the bootable_refreshing flag"
+    );
+}
+
+#[test]
 fn test_background_device_discovery_failure_clears_refreshing() {
     let mut state = AppState::new();
     state.show_new_session_dialog(crate::config::LoadedConfigs::default());

--- a/crates/fdemon-app/src/handler/tests.rs
+++ b/crates/fdemon-app/src/handler/tests.rs
@@ -3330,6 +3330,8 @@ mod auto_launch_tests {
 
         // Background errors should not show error UI when cached devices exist
         let mut state = AppState::new();
+        // Inject a fake SDK so the handler proceeds past the SDK-missing guard.
+        state.resolved_sdk = Some(fdemon_daemon::test_utils::fake_flutter_sdk());
 
         // Set up cached devices
         state.set_device_cache(vec![test_device("cached-1", "Cached Phone")]);

--- a/crates/fdemon-app/src/handler/tests.rs
+++ b/crates/fdemon-app/src/handler/tests.rs
@@ -10083,3 +10083,24 @@ fn test_devices_discovered_clears_refreshing() {
     let _ = update(&mut state, Message::DevicesDiscovered { devices: vec![] });
     assert!(!state.new_session_dialog_state.target_selector.refreshing);
 }
+
+#[test]
+fn test_background_device_discovery_failure_clears_refreshing() {
+    let mut state = AppState::new();
+    state.show_new_session_dialog(crate::config::LoadedConfigs::default());
+    state.set_device_cache(vec![test_device("dev1", "Device 1")]);
+    state.new_session_dialog_state.target_selector.refreshing = true;
+
+    let _ = update(
+        &mut state,
+        Message::DeviceDiscoveryFailed {
+            error: "transient flutter devices error".to_string(),
+            is_background: true,
+        },
+    );
+
+    assert!(
+        !state.new_session_dialog_state.target_selector.refreshing,
+        "background failure must clear the refreshing flag"
+    );
+}

--- a/crates/fdemon-app/src/handler/tests.rs
+++ b/crates/fdemon-app/src/handler/tests.rs
@@ -10073,3 +10073,13 @@ fn test_enter_devtools_with_network_default_queues_switch_panel_message() {
         "Lazy-start path with Network default should queue SwitchDevToolsPanel(Network)"
     );
 }
+
+#[test]
+fn test_devices_discovered_clears_refreshing() {
+    let mut state = AppState::new();
+    state.show_new_session_dialog(crate::config::LoadedConfigs::default());
+    state.new_session_dialog_state.target_selector.refreshing = true;
+
+    let _ = update(&mut state, Message::DevicesDiscovered { devices: vec![] });
+    assert!(!state.new_session_dialog_state.target_selector.refreshing);
+}

--- a/crates/fdemon-app/src/handler/update.rs
+++ b/crates/fdemon-app/src/handler/update.rs
@@ -410,6 +410,12 @@ pub fn update(state: &mut AppState, message: Message) -> UpdateResult {
                 // Background refresh - log error but don't show to user
                 // User can still select from cached devices
                 tracing::warn!("Background device refresh failed: {}", error);
+                // Clear the refreshing indicator so it doesn't stay stuck when the
+                // dialog is open. Do NOT touch bootable_refreshing — the bootable spawn
+                // swallows errors and never sends DeviceDiscoveryFailed.
+                if state.ui_mode == UiMode::NewSessionDialog || state.ui_mode == UiMode::Startup {
+                    state.new_session_dialog_state.target_selector.refreshing = false;
+                }
             } else {
                 // Foreground discovery - show error to user
                 // Update new_session_dialog_state if visible

--- a/crates/fdemon-app/src/new_session_dialog/target_selector_state.rs
+++ b/crates/fdemon-app/src/new_session_dialog/target_selector_state.rs
@@ -268,7 +268,14 @@ impl TargetSelectorState {
         }
     }
 
-    /// Set error state
+    /// Set the connected-discovery error state.
+    ///
+    /// Clears `loading` and `refreshing` because this is invoked only from the
+    /// connected-device foreground failure path (`Message::DeviceDiscoveryFailed`
+    /// with `is_background: false`). `bootable_refreshing` is intentionally **not**
+    /// cleared here — bootable failures are routed through their own paths
+    /// (`spawn_bootable_device_discovery` swallows errors via `unwrap_or_default()`),
+    /// and clearing the bootable indicator on a connected error would be misleading.
     pub fn set_error(&mut self, error: String) {
         self.error = Some(error);
         self.loading = false;

--- a/crates/fdemon-app/src/new_session_dialog/target_selector_state.rs
+++ b/crates/fdemon-app/src/new_session_dialog/target_selector_state.rs
@@ -41,6 +41,20 @@ pub struct TargetSelectorState {
     /// Loading state for bootable device discovery
     pub bootable_loading: bool,
 
+    /// Background refresh in progress for connected devices.
+    ///
+    /// Distinct from `loading`: `loading` shows a full-screen spinner with no
+    /// content, whereas `refreshing` is set when the cached list is already shown
+    /// and a background discovery is updating it in place. Cleared by
+    /// `set_connected_devices()` and `set_error()`.
+    pub refreshing: bool,
+
+    /// Background refresh in progress for bootable devices.
+    ///
+    /// Mirror of `refreshing` for the bootable tab. Cleared by
+    /// `set_bootable_devices()`.
+    pub bootable_refreshing: bool,
+
     /// Error message if discovery failed
     pub error: Option<String>,
 
@@ -69,6 +83,8 @@ impl Default for TargetSelectorState {
             selected_index: 0,
             loading: true,
             bootable_loading: true,
+            refreshing: false,
+            bootable_refreshing: false,
             error: None,
             scroll_offset: 0,
             last_known_visible_height: Cell::new(0),
@@ -212,6 +228,7 @@ impl TargetSelectorState {
     pub fn set_connected_devices(&mut self, devices: Vec<Device>) {
         self.connected_devices = devices;
         self.loading = false;
+        self.refreshing = false;
         self.error = None;
         self.invalidate_cache();
         self.scroll_offset = 0; // Reset scroll when devices change
@@ -234,6 +251,7 @@ impl TargetSelectorState {
         self.ios_simulators = ios_simulators;
         self.android_avds = android_avds;
         self.bootable_loading = false;
+        self.bootable_refreshing = false;
         // NOTE: do NOT clear self.error here — bootable device discovery uses
         // xcrun/emulator tools that are independent of the Flutter SDK.
         // SDK-level errors (e.g. "Flutter SDK not found") must persist until
@@ -254,6 +272,7 @@ impl TargetSelectorState {
     pub fn set_error(&mut self, error: String) {
         self.error = Some(error);
         self.loading = false;
+        self.refreshing = false;
     }
 
     /// Adjust scroll offset to keep selected item visible
@@ -390,6 +409,37 @@ mod tests {
         // Error should be cleared — successful device discovery means SDK is working
         assert!(state.error.is_none());
         assert!(!state.loading);
+    }
+
+    #[test]
+    fn test_refreshing_default_false() {
+        let state = TargetSelectorState::default();
+        assert!(!state.refreshing);
+        assert!(!state.bootable_refreshing);
+    }
+
+    #[test]
+    fn test_set_connected_devices_clears_refreshing() {
+        let mut state = TargetSelectorState::default();
+        state.refreshing = true;
+        state.set_connected_devices(vec![]);
+        assert!(!state.refreshing);
+    }
+
+    #[test]
+    fn test_set_bootable_devices_clears_bootable_refreshing() {
+        let mut state = TargetSelectorState::default();
+        state.bootable_refreshing = true;
+        state.set_bootable_devices(vec![], vec![]);
+        assert!(!state.bootable_refreshing);
+    }
+
+    #[test]
+    fn test_set_error_clears_refreshing() {
+        let mut state = TargetSelectorState::default();
+        state.refreshing = true;
+        state.set_error("boom".to_string());
+        assert!(!state.refreshing);
     }
 }
 

--- a/crates/fdemon-app/src/new_session_dialog/target_selector_state.rs
+++ b/crates/fdemon-app/src/new_session_dialog/target_selector_state.rs
@@ -268,14 +268,23 @@ impl TargetSelectorState {
         }
     }
 
-    /// Set the connected-discovery error state.
+    /// Set a new-session dialog error state.
     ///
-    /// Clears `loading` and `refreshing` because this is invoked only from the
-    /// connected-device foreground failure path (`Message::DeviceDiscoveryFailed`
-    /// with `is_background: false`). `bootable_refreshing` is intentionally **not**
-    /// cleared here — bootable failures are routed through their own paths
-    /// (`spawn_bootable_device_discovery` swallows errors via `unwrap_or_default()`),
-    /// and clearing the bootable indicator on a connected error would be misleading.
+    /// This helper is used by many new-session error paths, not just the
+    /// connected-device foreground discovery failure path. Callers include device
+    /// discovery failures, session creation failures, boot failures, config save
+    /// errors, "no Flutter SDK" surfaces from the launch context and dialog open,
+    /// and several validation paths.
+    ///
+    /// It records the error and clears the connected-side `loading` and
+    /// `refreshing` flags so the UI does not remain stuck in a connected
+    /// in-progress state after an error is surfaced.
+    ///
+    /// `bootable_loading` and `bootable_refreshing` are intentionally **not**
+    /// cleared here. Bootable discovery is independent (xcrun/emulator tools,
+    /// not the Flutter SDK) and its in-flight flags are managed by their own
+    /// success/failure paths. Callers that need to clear bootable indicators on
+    /// a particular error must do so themselves.
     pub fn set_error(&mut self, error: String) {
         self.error = Some(error);
         self.loading = false;

--- a/crates/fdemon-app/src/state.rs
+++ b/crates/fdemon-app/src/state.rs
@@ -1232,21 +1232,12 @@ impl AppState {
     // Device Cache Helpers (Task 08e)
     // ─────────────────────────────────────────────────────────
 
-    /// Get cached devices if fresh enough (within TTL)
+    /// Get cached devices.
     ///
-    /// Cache is considered valid for 30 seconds to balance freshness with responsiveness.
-    /// Device list changes are rare (device connects/disconnects) so this is a safe tradeoff.
+    /// Cache survives for the lifetime of AppState; the dialog always triggers a
+    /// background refresh on open to keep the list fresh.
     pub fn get_cached_devices(&self) -> Option<&Vec<Device>> {
-        // Cache TTL of 30 seconds
-        const CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
-
-        if let (Some(ref devices), Some(updated)) = (&self.device_cache, self.devices_last_updated)
-        {
-            if updated.elapsed() < CACHE_TTL {
-                return Some(devices);
-            }
-        }
-        None
+        self.device_cache.as_ref()
     }
 
     /// Update device cache with fresh devices
@@ -1262,25 +1253,16 @@ impl AppState {
     // Bootable Device Cache Helpers (Bug Fix: Task 03)
     // ─────────────────────────────────────────────────────────
 
-    /// Get cached bootable devices if fresh enough (within TTL)
+    /// Get cached bootable devices.
     ///
-    /// Returns both iOS simulators and Android AVDs from cache if valid.
-    /// Cache is considered valid for 30 seconds to balance freshness with responsiveness.
-    /// Bootable device changes are rare (simulator/AVD creation/deletion) so this is a safe tradeoff.
+    /// Returns both iOS simulators and Android AVDs from cache whenever both are
+    /// populated. Cache survives for the lifetime of AppState; the dialog always
+    /// triggers a background refresh on open to keep the list fresh.
     pub fn get_cached_bootable_devices(&self) -> Option<(Vec<IosSimulator>, Vec<AndroidAvd>)> {
-        // Cache TTL of 30 seconds (same as connected devices)
-        const CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
-
-        if let (Some(ref simulators), Some(ref avds), Some(updated)) = (
-            &self.ios_simulators_cache,
-            &self.android_avds_cache,
-            self.bootable_last_updated,
-        ) {
-            if updated.elapsed() < CACHE_TTL {
-                return Some((simulators.clone(), avds.clone()));
-            }
+        match (&self.ios_simulators_cache, &self.android_avds_cache) {
+            (Some(sims), Some(avds)) => Some((sims.clone(), avds.clone())),
+            _ => None,
         }
-        None
     }
 
     /// Update the bootable device cache with fresh results
@@ -1777,17 +1759,15 @@ mod tests {
     }
 
     #[test]
-    fn test_device_cache_expires() {
+    fn test_device_cache_does_not_expire() {
         let mut state = AppState::new();
         state.set_device_cache(vec![test_device("dev1", "Device 1")]);
 
-        // Fresh cache
-        assert!(state.get_cached_devices().is_some());
-
-        // Expired cache (mock time travel by manually setting timestamp)
+        // Simulate a stale timestamp — cache should still be returned.
         state.devices_last_updated =
-            Some(std::time::Instant::now() - std::time::Duration::from_secs(60));
-        assert!(state.get_cached_devices().is_none());
+            Some(std::time::Instant::now() - std::time::Duration::from_secs(60 * 60));
+        assert!(state.get_cached_devices().is_some());
+        assert_eq!(state.get_cached_devices().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/fdemon-app/src/state.rs
+++ b/crates/fdemon-app/src/state.rs
@@ -1255,12 +1255,15 @@ impl AppState {
 
     /// Get cached bootable devices.
     ///
-    /// Returns both iOS simulators and Android AVDs from cache whenever both are
-    /// populated. Cache survives for the lifetime of AppState; the dialog always
-    /// triggers a background refresh on open to keep the list fresh.
-    pub fn get_cached_bootable_devices(&self) -> Option<(Vec<IosSimulator>, Vec<AndroidAvd>)> {
+    /// Returns references to both iOS simulators and Android AVDs from cache whenever
+    /// both are populated. Cache survives for the lifetime of AppState; the dialog
+    /// always triggers a background refresh on open to keep the list fresh.
+    ///
+    /// The caller is responsible for cloning if it needs ownership (mirroring the
+    /// `get_cached_devices` pattern).
+    pub fn get_cached_bootable_devices(&self) -> Option<(&Vec<IosSimulator>, &Vec<AndroidAvd>)> {
         match (&self.ios_simulators_cache, &self.android_avds_cache) {
-            (Some(sims), Some(avds)) => Some((sims.clone(), avds.clone())),
+            (Some(sims), Some(avds)) => Some((sims, avds)),
             _ => None,
         }
     }

--- a/crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs
+++ b/crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs
@@ -330,7 +330,8 @@ impl<'a> NewSessionDialog<'a> {
             &self.state.target_selector,
             self.tool_availability,
             target_focused,
-        );
+        )
+        .icons(*self.icons);
         target_selector.render(chunks[0], buf);
 
         // Render vertical separator
@@ -553,6 +554,7 @@ impl<'a> NewSessionDialog<'a> {
             self.tool_availability,
             target_focused,
         )
+        .icons(*self.icons)
         .compact(target_compact);
         target_selector.render(chunks[2], buf);
 
@@ -1219,6 +1221,135 @@ mod tests {
             LaunchContext::min_height(),
             "MIN_EXPANDED_LAUNCH_HEIGHT must equal LaunchContext::min_height() \
              to avoid button clipping at the expanded threshold boundary"
+        );
+    }
+
+    // =========================================================================
+    // Group 6: IconSet threading — NewSessionDialog must pass configured icons
+    //          through to TargetSelector (and its TabBar) at both call sites.
+    // =========================================================================
+
+    /// Lock-in test: NewSessionDialog threads a non-default IconSet to TargetSelector
+    /// so that the configured refresh glyph appears in the rendered tab bar.
+    ///
+    /// The horizontal layout (width >= 70, height >= 20) exercises the call site
+    /// inside `render_panes()` (line ~329).
+    #[test]
+    fn test_new_session_dialog_threads_iconset_to_target_selector() {
+        // Build a NerdFonts icon set whose refresh glyph differs from the default (Unicode).
+        let nerd_icons = IconSet::new(IconMode::NerdFonts);
+        let nerd_refresh = nerd_icons.refresh(); // \u{f021}
+        let unicode_refresh = IconSet::default().refresh(); // \u{21bb} ↻
+
+        // Verify test setup: the two glyphs must differ; if they ever become equal,
+        // the test can no longer distinguish "threading worked" from "fallback used".
+        assert_ne!(
+            nerd_refresh, unicode_refresh,
+            "test setup error: NerdFonts refresh glyph must differ from Unicode default"
+        );
+
+        // Build dialog state with refreshing=true so the glyph is emitted by TabBar.
+        let mut state = NewSessionDialogState::new(LoadedConfigs::default());
+        state.target_selector.refreshing = true;
+
+        let tool_availability = ToolAvailability::default();
+        let dialog = NewSessionDialog::new(&state, &tool_availability, &nerd_icons);
+
+        // Render at a size that triggers horizontal (two-pane) layout.
+        // MIN_HORIZONTAL_WIDTH = 70, MIN_HORIZONTAL_HEIGHT = 20 — use 120×40 for headroom.
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).expect("test: failed to create terminal");
+
+        terminal
+            .draw(|f| {
+                f.render_widget(dialog, f.area());
+            })
+            .expect("test: failed to draw");
+
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+
+        assert!(
+            rendered.contains(nerd_refresh),
+            "expected NerdFonts refresh glyph ({}) in rendered tab bar, got: {:?}",
+            nerd_refresh,
+            &rendered.chars().take(400).collect::<String>()
+        );
+        assert!(
+            !rendered.contains(unicode_refresh),
+            "default Unicode refresh glyph ({}) must NOT appear when NerdFonts is \
+             configured — threading is broken if it does. got: {:?}",
+            unicode_refresh,
+            &rendered.chars().take(400).collect::<String>()
+        );
+    }
+
+    /// Lock-in test for the vertical (compact) layout call site in `render_vertical()`
+    /// (~line 551). Renders into a narrow terminal (width 40–69) with sufficient height
+    /// to trigger the vertical layout path.
+    ///
+    /// Uses `bootable_refreshing = true` with the active tab set to Bootable so the
+    /// glyph appears in the compact tab bar rendered by `render_tabs_compact`.
+    #[test]
+    fn test_new_session_dialog_threads_iconset_to_target_selector_vertical() {
+        let nerd_icons = IconSet::new(IconMode::NerdFonts);
+        let nerd_refresh = nerd_icons.refresh();
+        let unicode_refresh = IconSet::default().refresh();
+
+        assert_ne!(
+            nerd_refresh, unicode_refresh,
+            "test setup error: NerdFonts refresh glyph must differ from Unicode default"
+        );
+
+        // Build dialog state with Bootable tab active and bootable_refreshing=true.
+        // Note: set_bootable_devices() resets bootable_refreshing to false, so we
+        // must set bootable_refreshing AFTER the call to preserve the in-flight state.
+        let mut state = NewSessionDialogState::new(LoadedConfigs::default());
+        state.target_selector.active_tab = TargetTab::Bootable;
+        state.target_selector.loading = false;
+        state.target_selector.set_bootable_devices(vec![], vec![]);
+        state.target_selector.bootable_refreshing = true;
+
+        let tool_availability = ToolAvailability::default();
+        let dialog = NewSessionDialog::new(&state, &tool_availability, &nerd_icons);
+
+        // Render at a size that triggers vertical layout:
+        // MIN_VERTICAL_WIDTH=40, MIN_VERTICAL_HEIGHT=20 — use 50×40 (below horizontal
+        // threshold of 70 wide, above vertical threshold of 40 wide and 20 tall).
+        let backend = TestBackend::new(50, 40);
+        let mut terminal = Terminal::new(backend).expect("test: failed to create terminal");
+
+        terminal
+            .draw(|f| {
+                f.render_widget(dialog, f.area());
+            })
+            .expect("test: failed to draw");
+
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+
+        assert!(
+            rendered.contains(nerd_refresh),
+            "expected NerdFonts refresh glyph ({}) in vertical-layout rendered tab bar, got: {:?}",
+            nerd_refresh,
+            &rendered.chars().take(400).collect::<String>()
+        );
+        assert!(
+            !rendered.contains(unicode_refresh),
+            "default Unicode refresh glyph ({}) must NOT appear when NerdFonts is \
+             configured in vertical layout. got: {:?}",
+            unicode_refresh,
+            &rendered.chars().take(400).collect::<String>()
         );
     }
 }

--- a/crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs
+++ b/crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs
@@ -17,13 +17,24 @@ pub struct TabBar {
     active_tab: TargetTab,
     /// Whether this pane is focused
     pane_focused: bool,
+    /// Refresh-in-flight indicator for the Connected tab.
+    connected_refreshing: bool,
+    /// Refresh-in-flight indicator for the Bootable tab.
+    bootable_refreshing: bool,
 }
 
 impl TabBar {
-    pub fn new(active_tab: TargetTab, pane_focused: bool) -> Self {
+    pub fn new(
+        active_tab: TargetTab,
+        pane_focused: bool,
+        connected_refreshing: bool,
+        bootable_refreshing: bool,
+    ) -> Self {
         Self {
             active_tab,
             pane_focused,
+            connected_refreshing,
+            bootable_refreshing,
         }
     }
 }
@@ -51,7 +62,16 @@ impl Widget for TabBar {
             .enumerate()
         {
             let is_active = *tab == self.active_tab;
-            let label = tab.label();
+            let refreshing = match tab {
+                TargetTab::Connected => self.connected_refreshing,
+                TargetTab::Bootable => self.bootable_refreshing,
+            };
+
+            let label = if refreshing {
+                format!("{} ↻", tab.label())
+            } else {
+                tab.label().to_string()
+            };
 
             let style = if is_active && self.pane_focused {
                 Style::default()
@@ -110,7 +130,7 @@ mod tests {
 
         terminal
             .draw(|f| {
-                let tab_bar = TabBar::new(TargetTab::Connected, true);
+                let tab_bar = TabBar::new(TargetTab::Connected, true, false, false);
                 f.render_widget(tab_bar, f.area());
             })
             .unwrap();
@@ -129,7 +149,7 @@ mod tests {
 
         terminal
             .draw(|f| {
-                let tab_bar = TabBar::new(TargetTab::Bootable, true);
+                let tab_bar = TabBar::new(TargetTab::Bootable, true, false, false);
                 f.render_widget(tab_bar, f.area());
             })
             .unwrap();
@@ -148,7 +168,7 @@ mod tests {
 
         terminal
             .draw(|f| {
-                let tab_bar = TabBar::new(TargetTab::Connected, false);
+                let tab_bar = TabBar::new(TargetTab::Connected, false, false, false);
                 f.render_widget(tab_bar, f.area());
             })
             .unwrap();
@@ -159,5 +179,68 @@ mod tests {
         // Should still render both tabs
         assert!(content.contains("Connected"));
         assert!(content.contains("Bootable"));
+    }
+
+    #[test]
+    fn test_tab_bar_renders_connected_refreshing_indicator() {
+        let backend = TestBackend::new(40, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let tab_bar = TabBar::new(TargetTab::Connected, true, true, false);
+                f.render_widget(tab_bar, f.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let rendered: String = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            rendered.contains("↻"),
+            "expected refresh glyph on Connected tab, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_tab_bar_renders_bootable_refreshing_indicator() {
+        let backend = TestBackend::new(40, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let tab_bar = TabBar::new(TargetTab::Bootable, true, false, true);
+                f.render_widget(tab_bar, f.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let rendered: String = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(rendered.contains("↻"));
+    }
+
+    #[test]
+    fn test_tab_bar_no_indicator_when_not_refreshing() {
+        let backend = TestBackend::new(40, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let tab_bar = TabBar::new(TargetTab::Connected, true, false, false);
+                f.render_widget(tab_bar, f.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let rendered: String = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(!rendered.contains("↻"));
     }
 }

--- a/crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs
+++ b/crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs
@@ -10,10 +10,10 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Widget},
 };
 
-use crate::theme::palette;
+use crate::theme::{icons::IconSet, palette};
 
 /// Tab bar widget for switching between Connected and Bootable views
-pub struct TabBar {
+pub struct TabBar<'a> {
     active_tab: TargetTab,
     /// Whether this pane is focused
     pane_focused: bool,
@@ -21,25 +21,29 @@ pub struct TabBar {
     connected_refreshing: bool,
     /// Refresh-in-flight indicator for the Bootable tab.
     bootable_refreshing: bool,
+    /// Icon set for resolving glyphs (Unicode vs Nerd Fonts).
+    icons: &'a IconSet,
 }
 
-impl TabBar {
+impl<'a> TabBar<'a> {
     pub fn new(
         active_tab: TargetTab,
         pane_focused: bool,
         connected_refreshing: bool,
         bootable_refreshing: bool,
+        icons: &'a IconSet,
     ) -> Self {
         Self {
             active_tab,
             pane_focused,
             connected_refreshing,
             bootable_refreshing,
+            icons,
         }
     }
 }
 
-impl Widget for TabBar {
+impl Widget for TabBar<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         // Outer container: dark background with rounded border
         let container_bg = palette::DEEPEST_BG;
@@ -68,7 +72,7 @@ impl Widget for TabBar {
             };
 
             let label = if refreshing {
-                format!("{} ↻", tab.label())
+                format!("{} {}", tab.label(), self.icons.refresh())
             } else {
                 tab.label().to_string()
             };
@@ -97,6 +101,7 @@ impl Widget for TabBar {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::theme::icons::IconSet;
     use ratatui::{backend::TestBackend, Terminal};
 
     #[test]
@@ -125,12 +130,13 @@ mod tests {
 
     #[test]
     fn test_tab_bar_renders() {
+        let icons = IconSet::default();
         let backend = TestBackend::new(40, 3);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
             .draw(|f| {
-                let tab_bar = TabBar::new(TargetTab::Connected, true, false, false);
+                let tab_bar = TabBar::new(TargetTab::Connected, true, false, false, &icons);
                 f.render_widget(tab_bar, f.area());
             })
             .unwrap();
@@ -144,12 +150,13 @@ mod tests {
 
     #[test]
     fn test_tab_bar_renders_with_bootable_active() {
+        let icons = IconSet::default();
         let backend = TestBackend::new(40, 3);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
             .draw(|f| {
-                let tab_bar = TabBar::new(TargetTab::Bootable, true, false, false);
+                let tab_bar = TabBar::new(TargetTab::Bootable, true, false, false, &icons);
                 f.render_widget(tab_bar, f.area());
             })
             .unwrap();
@@ -163,12 +170,13 @@ mod tests {
 
     #[test]
     fn test_tab_bar_unfocused() {
+        let icons = IconSet::default();
         let backend = TestBackend::new(40, 3);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
             .draw(|f| {
-                let tab_bar = TabBar::new(TargetTab::Connected, false, false, false);
+                let tab_bar = TabBar::new(TargetTab::Connected, false, false, false, &icons);
                 f.render_widget(tab_bar, f.area());
             })
             .unwrap();
@@ -183,11 +191,13 @@ mod tests {
 
     #[test]
     fn test_tab_bar_renders_connected_refreshing_indicator() {
+        let icons = IconSet::default();
+        let glyph = icons.refresh();
         let backend = TestBackend::new(40, 3);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                let tab_bar = TabBar::new(TargetTab::Connected, true, true, false);
+                let tab_bar = TabBar::new(TargetTab::Connected, true, true, false, &icons);
                 f.render_widget(tab_bar, f.area());
             })
             .unwrap();
@@ -199,18 +209,20 @@ mod tests {
             .collect::<Vec<_>>()
             .join("");
         assert!(
-            rendered.contains("↻"),
+            rendered.contains(glyph),
             "expected refresh glyph on Connected tab, got: {rendered}"
         );
     }
 
     #[test]
     fn test_tab_bar_renders_bootable_refreshing_indicator() {
+        let icons = IconSet::default();
+        let glyph = icons.refresh();
         let backend = TestBackend::new(40, 3);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                let tab_bar = TabBar::new(TargetTab::Bootable, true, false, true);
+                let tab_bar = TabBar::new(TargetTab::Bootable, true, false, true, &icons);
                 f.render_widget(tab_bar, f.area());
             })
             .unwrap();
@@ -221,16 +233,21 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<Vec<_>>()
             .join("");
-        assert!(rendered.contains("↻"));
+        assert!(
+            rendered.contains(glyph),
+            "expected refresh glyph on Bootable tab, got: {rendered}"
+        );
     }
 
     #[test]
     fn test_tab_bar_no_indicator_when_not_refreshing() {
+        let icons = IconSet::default();
+        let glyph = icons.refresh();
         let backend = TestBackend::new(40, 3);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                let tab_bar = TabBar::new(TargetTab::Connected, true, false, false);
+                let tab_bar = TabBar::new(TargetTab::Connected, true, false, false, &icons);
                 f.render_widget(tab_bar, f.area());
             })
             .unwrap();
@@ -241,6 +258,6 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<Vec<_>>()
             .join("");
-        assert!(!rendered.contains("↻"));
+        assert!(!rendered.contains(glyph));
     }
 }

--- a/crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs
+++ b/crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs
@@ -230,25 +230,29 @@ impl TargetSelector<'_> {
             .add_modifier(Modifier::BOLD);
         let style_inactive = Style::default().fg(palette::TEXT_MUTED);
 
-        // Build labels with optional refresh glyph for the active tab's in-flight state.
-        let connected_label = if connected_active {
-            if self.state.refreshing {
-                format!("[1 Connected {}]", self.icons.refresh())
-            } else {
-                "[1 Connected]".to_string()
-            }
+        // Build the base label (active-tab brackets vs bare), then conditionally
+        // append the refresh glyph for any tab whose refresh is in flight. This
+        // mirrors `TabBar`'s per-tab semantics in full mode.
+        let connected_base = if connected_active {
+            "[1 Connected]"
         } else {
-            "1 Connected".to_string()
+            "1 Connected"
+        };
+        let connected_label = if self.state.refreshing {
+            format!("{} {}", connected_base, self.icons.refresh())
+        } else {
+            connected_base.to_string()
         };
 
-        let bootable_label = if bootable_active {
-            if self.state.bootable_refreshing {
-                format!("[2 Bootable {}]", self.icons.refresh())
-            } else {
-                "[2 Bootable]".to_string()
-            }
+        let bootable_base = if bootable_active {
+            "[2 Bootable]"
         } else {
-            "2 Bootable".to_string()
+            "2 Bootable"
+        };
+        let bootable_label = if self.state.bootable_refreshing {
+            format!("{} {}", bootable_base, self.icons.refresh())
+        } else {
+            bootable_base.to_string()
         };
 
         // Pill-style compact: use brackets for active tab
@@ -1229,5 +1233,80 @@ mod tests {
             rendered.contains(glyph),
             "compact mode should show refresh glyph when active tab is refreshing, got: {rendered}"
         );
+    }
+
+    #[test]
+    fn test_target_selector_compact_renders_refreshing_glyph_on_inactive_tab() {
+        // Case 1: Active tab is Connected, but Bootable is refreshing (inactive tab).
+        // The glyph must appear next to the inactive Bootable label.
+        {
+            let mut state = TargetSelectorState::default();
+            state.loading = false;
+            state.set_connected_devices(vec![test_device_full("1", "iPhone", "ios", false)]);
+            state.bootable_refreshing = true;
+            state.active_tab = TargetTab::Connected;
+
+            let tool_availability = ToolAvailability::default();
+            let icons = crate::theme::icons::IconSet::default();
+            let glyph = icons.refresh();
+
+            let backend = TestBackend::new(50, 10);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|f| {
+                    let selector =
+                        TargetSelector::new(&state, &tool_availability, true).compact(true);
+                    selector.render(f.area(), f.buffer_mut());
+                })
+                .unwrap();
+            let rendered: String = terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect::<Vec<_>>()
+                .join("");
+            assert!(
+                rendered.contains(glyph),
+                "expected refresh glyph on inactive Bootable tab in compact mode, got: {rendered}"
+            );
+        }
+
+        // Case 2: Active tab is Bootable, but Connected is refreshing (inactive tab).
+        // The glyph must appear next to the inactive Connected label.
+        {
+            let mut state = TargetSelectorState::default();
+            state.loading = false;
+            state.set_connected_devices(vec![test_device_full("1", "iPhone", "ios", false)]);
+            state.refreshing = true;
+            state.active_tab = TargetTab::Bootable;
+
+            let tool_availability = ToolAvailability::default();
+            let icons = crate::theme::icons::IconSet::default();
+            let glyph = icons.refresh();
+
+            let backend = TestBackend::new(50, 10);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|f| {
+                    let selector =
+                        TargetSelector::new(&state, &tool_availability, true).compact(true);
+                    selector.render(f.area(), f.buffer_mut());
+                })
+                .unwrap();
+            let rendered: String = terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect::<Vec<_>>()
+                .join("");
+            assert!(
+                rendered.contains(glyph),
+                "expected refresh glyph on inactive Connected tab in compact mode, got: {rendered}"
+            );
+        }
     }
 }

--- a/crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs
+++ b/crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs
@@ -89,7 +89,8 @@ impl TargetSelector<'_> {
         );
 
         // Render tab bar
-        let tab_bar = TabBar::new(self.state.active_tab, self.is_focused);
+        // Note: refreshing flags will be wired to real state in task 06.
+        let tab_bar = TabBar::new(self.state.active_tab, self.is_focused, false, false);
         tab_bar.render(chunks[0], buf);
 
         // Render content based on active tab

--- a/crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs
+++ b/crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs
@@ -89,8 +89,12 @@ impl TargetSelector<'_> {
         );
 
         // Render tab bar
-        // Note: refreshing flags will be wired to real state in task 06.
-        let tab_bar = TabBar::new(self.state.active_tab, self.is_focused, false, false);
+        let tab_bar = TabBar::new(
+            self.state.active_tab,
+            self.is_focused,
+            self.state.refreshing,
+            self.state.bootable_refreshing,
+        );
         tab_bar.render(chunks[0], buf);
 
         // Render content based on active tab
@@ -1007,6 +1011,106 @@ mod tests {
             content.contains("Dev 1"),
             "Selected device 'Dev 1' (flat index 2) should be visible after scroll correction; content: {}",
             &content.chars().take(200).collect::<String>()
+        );
+    }
+
+    #[test]
+    fn test_target_selector_renders_refreshing_glyph_when_state_set() {
+        // render_full layout: Length(3) tab bar + Min(5) content + Length(1) footer
+        // Use height 12 to ensure the tab bar renders fully and the ↻ glyph is visible.
+        let mut state = TargetSelectorState::default();
+        state.loading = false;
+        state.set_connected_devices(vec![test_device_full("1", "iPhone", "ios", false)]);
+        state.refreshing = true;
+
+        let tool_availability = ToolAvailability::default();
+
+        let backend = TestBackend::new(60, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let selector = TargetSelector::new(&state, &tool_availability, true);
+                selector.render(f.area(), f.buffer_mut());
+            })
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            rendered.contains("↻"),
+            "expected refresh glyph in target selector, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_target_selector_renders_bootable_refreshing_glyph_when_state_set() {
+        // render_full layout: Length(3) tab bar + Min(5) content + Length(1) footer
+        // Use height 12 to ensure the tab bar renders fully and the ↻ glyph is visible.
+        let mut state = TargetSelectorState::default();
+        state.loading = false;
+        state.active_tab = TargetTab::Bootable;
+        state.set_bootable_devices(vec![], vec![]);
+        state.bootable_refreshing = true;
+
+        let tool_availability = ToolAvailability::default();
+
+        let backend = TestBackend::new(60, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let selector = TargetSelector::new(&state, &tool_availability, true);
+                selector.render(f.area(), f.buffer_mut());
+            })
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            rendered.contains("↻"),
+            "expected bootable refresh glyph in target selector, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_target_selector_no_glyph_when_not_refreshing() {
+        // render_full layout: Length(3) tab bar + Min(5) content + Length(1) footer
+        // Use height 12 to ensure the tab bar renders fully.
+        let mut state = TargetSelectorState::default();
+        state.loading = false;
+        state.set_connected_devices(vec![test_device_full("1", "iPhone", "ios", false)]);
+        // refreshing defaults to false
+
+        let tool_availability = ToolAvailability::default();
+
+        let backend = TestBackend::new(60, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let selector = TargetSelector::new(&state, &tool_availability, true);
+                selector.render(f.area(), f.buffer_mut());
+            })
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            !rendered.contains("↻"),
+            "expected no refresh glyph when not refreshing, got: {rendered}"
         );
     }
 

--- a/crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs
+++ b/crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs
@@ -16,7 +16,7 @@ use super::tab_bar::TabBar;
 use super::TargetTab;
 use fdemon_app::ToolAvailability;
 
-use crate::theme::palette;
+use crate::theme::{icons::IconSet, palette};
 
 // Re-export TargetSelectorState from app layer for backward compatibility
 pub use fdemon_app::new_session_dialog::TargetSelectorState;
@@ -25,6 +25,8 @@ pub use fdemon_app::new_session_dialog::TargetSelectorState;
 pub struct TargetSelector<'a> {
     state: &'a TargetSelectorState,
     tool_availability: &'a ToolAvailability,
+    /// Icon set for resolving glyphs (Unicode vs Nerd Fonts).
+    icons: IconSet,
     is_focused: bool,
     compact: bool,
 }
@@ -38,9 +40,19 @@ impl<'a> TargetSelector<'a> {
         Self {
             state,
             tool_availability,
+            icons: IconSet::default(),
             is_focused,
             compact: false,
         }
+    }
+
+    /// Set the icon set for this widget (builder pattern).
+    ///
+    /// Callers that have a configured `IconSet` (e.g. from `NewSessionDialog`)
+    /// should pass it here to ensure Nerd Font glyphs are used when configured.
+    pub fn icons(mut self, icons: IconSet) -> Self {
+        self.icons = icons;
+        self
     }
 
     /// Enable compact mode for narrow terminals
@@ -94,6 +106,7 @@ impl TargetSelector<'_> {
             self.is_focused,
             self.state.refreshing,
             self.state.bootable_refreshing,
+            &self.icons,
         );
         tab_bar.render(chunks[0], buf);
 
@@ -217,14 +230,31 @@ impl TargetSelector<'_> {
             .add_modifier(Modifier::BOLD);
         let style_inactive = Style::default().fg(palette::TEXT_MUTED);
 
+        // Build labels with optional refresh glyph for the active tab's in-flight state.
+        let connected_label = if connected_active {
+            if self.state.refreshing {
+                format!("[1 Connected {}]", self.icons.refresh())
+            } else {
+                "[1 Connected]".to_string()
+            }
+        } else {
+            "1 Connected".to_string()
+        };
+
+        let bootable_label = if bootable_active {
+            if self.state.bootable_refreshing {
+                format!("[2 Bootable {}]", self.icons.refresh())
+            } else {
+                "[2 Bootable]".to_string()
+            }
+        } else {
+            "2 Bootable".to_string()
+        };
+
         // Pill-style compact: use brackets for active tab
         let tabs = vec![
             Span::styled(
-                if connected_active {
-                    "[1 Connected]"
-                } else {
-                    "1 Connected"
-                },
+                connected_label,
                 if connected_active {
                     style_active
                 } else {
@@ -233,11 +263,7 @@ impl TargetSelector<'_> {
             ),
             Span::raw("  "),
             Span::styled(
-                if bootable_active {
-                    "[2 Bootable]"
-                } else {
-                    "2 Bootable"
-                },
+                bootable_label,
                 if bootable_active {
                     style_active
                 } else {
@@ -1017,13 +1043,15 @@ mod tests {
     #[test]
     fn test_target_selector_renders_refreshing_glyph_when_state_set() {
         // render_full layout: Length(3) tab bar + Min(5) content + Length(1) footer
-        // Use height 12 to ensure the tab bar renders fully and the ↻ glyph is visible.
+        // Use height 12 to ensure the tab bar renders fully and the refresh glyph is visible.
         let mut state = TargetSelectorState::default();
         state.loading = false;
         state.set_connected_devices(vec![test_device_full("1", "iPhone", "ios", false)]);
         state.refreshing = true;
 
         let tool_availability = ToolAvailability::default();
+        let icons = crate::theme::icons::IconSet::default();
+        let glyph = icons.refresh();
 
         let backend = TestBackend::new(60, 12);
         let mut terminal = Terminal::new(backend).unwrap();
@@ -1042,7 +1070,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("");
         assert!(
-            rendered.contains("↻"),
+            rendered.contains(glyph),
             "expected refresh glyph in target selector, got: {rendered}"
         );
     }
@@ -1050,7 +1078,7 @@ mod tests {
     #[test]
     fn test_target_selector_renders_bootable_refreshing_glyph_when_state_set() {
         // render_full layout: Length(3) tab bar + Min(5) content + Length(1) footer
-        // Use height 12 to ensure the tab bar renders fully and the ↻ glyph is visible.
+        // Use height 12 to ensure the tab bar renders fully and the refresh glyph is visible.
         let mut state = TargetSelectorState::default();
         state.loading = false;
         state.active_tab = TargetTab::Bootable;
@@ -1058,6 +1086,8 @@ mod tests {
         state.bootable_refreshing = true;
 
         let tool_availability = ToolAvailability::default();
+        let icons = crate::theme::icons::IconSet::default();
+        let glyph = icons.refresh();
 
         let backend = TestBackend::new(60, 12);
         let mut terminal = Terminal::new(backend).unwrap();
@@ -1076,7 +1106,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("");
         assert!(
-            rendered.contains("↻"),
+            rendered.contains(glyph),
             "expected bootable refresh glyph in target selector, got: {rendered}"
         );
     }
@@ -1091,6 +1121,8 @@ mod tests {
         // refreshing defaults to false
 
         let tool_availability = ToolAvailability::default();
+        let icons = crate::theme::icons::IconSet::default();
+        let glyph = icons.refresh();
 
         let backend = TestBackend::new(60, 12);
         let mut terminal = Terminal::new(backend).unwrap();
@@ -1109,7 +1141,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("");
         assert!(
-            !rendered.contains("↻"),
+            !rendered.contains(glyph),
             "expected no refresh glyph when not refreshing, got: {rendered}"
         );
     }
@@ -1161,5 +1193,41 @@ mod tests {
                 expected
             );
         }
+    }
+
+    #[test]
+    fn test_target_selector_compact_renders_refreshing_glyph() {
+        // Use a height small enough to trigger compact mode via the caller (compact(true)).
+        // compact mode renders a single-line tab bar via render_tabs_compact.
+        let mut state = TargetSelectorState::default();
+        state.loading = false;
+        state.set_connected_devices(vec![test_device_full("1", "iPhone", "ios", false)]);
+        state.refreshing = true;
+        state.active_tab = TargetTab::Connected;
+
+        let tool_availability = ToolAvailability::default();
+        let icons = crate::theme::icons::IconSet::default();
+        let glyph = icons.refresh();
+
+        let backend = TestBackend::new(50, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let selector = TargetSelector::new(&state, &tool_availability, true).compact(true);
+                selector.render(f.area(), f.buffer_mut());
+            })
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            rendered.contains(glyph),
+            "compact mode should show refresh glyph when active tab is refreshing, got: {rendered}"
+        );
     }
 }

--- a/workflow/plans/bugs/device-cache-followup/BUG.md
+++ b/workflow/plans/bugs/device-cache-followup/BUG.md
@@ -1,0 +1,312 @@
+# Bugfix Plan: Device Cache No-TTL Review Follow-up
+
+## TL;DR
+
+Address blocking findings from
+[`workflow/reviews/bugs/device-cache-no-ttl/REVIEW.md`](../../../reviews/bugs/device-cache-no-ttl/REVIEW.md):
+
+- **C1 (Critical):** background discovery failures leave the `↻` indicator stuck on the
+  Connected tab.
+- **M1 (Major):** when both caches are empty, only the connected discovery is kicked off;
+  the bootable list silently sits at its default `loading` state until the user manually
+  switches tabs — contradicting the milestone deliverable of the parent plan.
+- **M2 (Major):** `get_cached_bootable_devices()` clones the entire bootable cache on
+  every call, asymmetric with the connected accessor and hidden in a code path advertised
+  as "instant."
+
+Plus selected minor cleanups: route the `↻` glyph through the existing `IconSet` (which
+already has Nerd Fonts and Unicode variants but is bypassed by an inline literal), surface
+the indicator in compact mode, and bundle small polish items.
+
+Parent plan: [`workflow/plans/bugs/device-cache-no-ttl/BUG.md`](../device-cache-no-ttl/BUG.md)
+
+---
+
+## Bug Report
+
+### Symptom
+
+After the device-cache-no-ttl change merged:
+
+1. **Stuck `↻` indicator on background failure.** Open the new-session dialog with a cached
+   device list. If the background `flutter devices` refresh fails (transient subprocess
+   error, missing executable, etc.), the `↻` glyph on the Connected tab remains visible
+   indefinitely — until the user closes and reopens the dialog. The data is fine (cached
+   list still shown); the indicator is misleading.
+2. **Bootable tab frozen on first dialog open with empty caches.** On a clean startup
+   where neither cache has populated yet, opening the dialog dispatches only the connected
+   discovery. The Bootable tab sits showing its default loading state with no
+   discovery actually in flight, until the user manually switches to it (which fires
+   `handle_switch_tab` and triggers discovery on demand).
+3. **Hidden allocation in the bootable cache hit path.** Every dialog open with a populated
+   bootable cache clones two `Vec`s inside `get_cached_bootable_devices()`. The connected
+   accessor returns a borrow.
+
+### Expected
+
+- The `↻` indicator clears on every discovery completion path, including background
+  failure.
+- Opening the new-session dialog refreshes both lists, regardless of cache state — matching
+  the parent plan's stated milestone.
+- The bootable cache accessor returns references; the single caller clones explicitly.
+
+### Root Causes
+
+#### C1 — Background-failure clearing path
+
+`crates/fdemon-app/src/handler/update.rs:405-428`. The `is_background: true` arm of
+`Message::DeviceDiscoveryFailed` only logs a warning:
+
+```rust
+if is_background {
+    tracing::warn!("Background device refresh failed: {}", error);
+} else {
+    if state.ui_mode == UiMode::Startup || state.ui_mode == UiMode::NewSessionDialog {
+        state.new_session_dialog_state.target_selector.set_error(error.clone());
+    }
+    tracing::error!("Device discovery failed: {}", error);
+}
+```
+
+`set_error()` (the only place `refreshing` is cleared on a *failure*) is reached only
+through the foreground branch. Background failures fall through to `UpdateResult::none()`
+without touching `refreshing`. The new `RefreshDevicesAndBootableBackground` action sends
+its connected-discovery failures through `is_background: true`
+(`crates/fdemon-app/src/spawn.rs:45-68`).
+
+The parent plan's "Cache Becoming Severely Stale" mitigation
+(`workflow/plans/bugs/device-cache-no-ttl/BUG.md:191`) explicitly — and incorrectly —
+claims `set_error()` handles this case.
+
+**Note:** The bootable side is not affected by this exact bug. `spawn_bootable_device_discovery`
+(`spawn.rs:570-591`) swallows errors via `unwrap_or_default()` and always sends a successful
+`BootableDevicesDiscovered` message, which calls `set_bootable_devices()` and clears
+`bootable_refreshing`. Bootable failures are silently hidden, but the indicator does clear.
+
+#### M1 — Cache-miss bootable discovery
+
+`crates/fdemon-app/src/handler/new_session/navigation.rs:258-261`. When both caches are
+empty, the cache-miss fallback dispatches `UpdateAction::DiscoverDevices { flutter }`,
+which (in `actions/mod.rs:75-77`) calls only `spawn::spawn_device_discovery`. There is no
+sibling spawn for bootable discovery.
+
+The existing `RefreshDevicesAndBootableBackground` is a background variant only — it sends
+`is_background: true` failures and doesn't set `loading`. We need the same parallel-spawn
+shape but with the foreground connected discovery so the user gets a proper loading
+indicator and surfaced errors.
+
+#### M2 — Owned-return bootable accessor
+
+`crates/fdemon-app/src/state.rs:1261-1266`:
+
+```rust
+pub fn get_cached_bootable_devices(&self) -> Option<(Vec<IosSimulator>, Vec<AndroidAvd>)> {
+    match (&self.ios_simulators_cache, &self.android_avds_cache) {
+        (Some(sims), Some(avds)) => Some((sims.clone(), avds.clone())),
+        _ => None,
+    }
+}
+```
+
+The owned return forces clones inside the accessor. The single caller
+(`navigation.rs:221-234`) takes ownership via `set_bootable_devices(simulators, avds)` —
+the ownership requirement is real, but the clone should live at the call site to mirror
+the connected-device pattern (`get_cached_devices` returns `Option<&Vec<Device>>`).
+
+#### m2 — `↻` glyph bypasses `IconSet`
+
+`crates/fdemon-tui/src/theme/icons.rs:96` already exposes `IconSet::refresh()` returning
+`"\u{21bb}"` (= `↻`) for `IconMode::Unicode` and the Nerd Font equivalent for
+`IconMode::NerdFonts`. `tab_bar.rs:71` ignores this and hardcodes the literal `"↻"`:
+
+```rust
+let label = format!("{} ↻", tab.label());
+```
+
+Result: Nerd Fonts users see the wrong glyph. The fix is to thread `&IconSet` into
+`TabBar::new()` (mirroring the `&'a IconSet` pattern already in
+`new_session_dialog/mod.rs:162-175`) and call `icons.refresh()`.
+
+---
+
+## Affected Modules
+
+| Module | Change |
+|---|---|
+| `crates/fdemon-app/src/handler/update.rs` | C1: clear `refreshing` in `is_background: true` arm when dialog is visible |
+| `crates/fdemon-app/src/handler/tests.rs` | C1: integration test for background-failure clearing; m1: symmetric `BootableDevicesDiscovered` test |
+| `crates/fdemon-app/src/handler/mod.rs` | M1: add `UpdateAction::DiscoverDevicesAndBootable { flutter }`; n1: multi-line `RefreshDevicesAndBootableBackground` doc |
+| `crates/fdemon-app/src/actions/mod.rs` | M1: wire new action — foreground connected + background bootable in parallel |
+| `crates/fdemon-app/src/handler/new_session/navigation.rs` | M1: cache-miss branch dispatches new action; M2: clone at call site; m5: race comment; m7: collapse dead branch; n3: extract `len()` |
+| `crates/fdemon-app/src/state.rs` | M2: `get_cached_bootable_devices()` returns refs |
+| `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | m3: comment on `set_error` asymmetric clearing |
+| `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs` | m2: thread `&IconSet`, call `icons.refresh()`; n2: assertion message |
+| `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | m2: pass `&IconSet` into `TabBar::new()`; m4: render `↻` in compact mode |
+| `workflow/plans/bugs/device-cache-no-ttl/BUG.md` | Correct line 191 mitigation note |
+
+---
+
+## Phases
+
+### Phase 1 — Blocking fixes
+
+**Goal:** every reviewer-flagged blocking finding is addressed and verified.
+
+**Steps (per task):**
+
+1. **C1 — Clear `refreshing` on background failure.** Edit the `is_background: true`
+   arm in `update.rs` to clear the flag when the dialog is visible. Add an integration
+   test that opens the dialog with a cached list, fires
+   `Message::DeviceDiscoveryFailed { is_background: true }`, and asserts
+   `refreshing == false`. Update the parent plan's BUG.md line 191.
+
+2. **M2 — Reference-returning accessor.** Change `get_cached_bootable_devices()` to
+   return `Option<(&Vec<IosSimulator>, &Vec<AndroidAvd>)>`. The single caller in
+   `navigation.rs` clones explicitly when forwarding to `set_bootable_devices`. Pure
+   refactor; existing tests should pass unchanged.
+
+3. **M1 — `DiscoverDevicesAndBootable` action.** Add the new variant to `UpdateAction`,
+   wire its match arm in `actions/mod.rs` to spawn both `spawn_device_discovery`
+   (foreground) and `spawn_bootable_device_discovery` (background) in parallel. Replace
+   the `DiscoverDevices` dispatch in the cache-miss fallback with the new variant. Add
+   a unit test.
+
+**Measurable Outcomes:**
+
+- After a transient `flutter devices` failure during a background refresh, the `↻`
+  glyph clears within one frame.
+- Opening the dialog with both caches empty kicks off both discoveries (foreground
+  connected with loading spinner; background bootable populates the Bootable tab on
+  arrival).
+- `cargo test -p fdemon-app --lib` passes.
+
+### Phase 2 — Polish
+
+**Goal:** route the refresh glyph through the existing `IconSet`, surface the indicator
+in compact mode, and apply minor cleanups.
+
+**Steps (per task):**
+
+4. **m2 + m4 + n2 — Icon routing + compact mode + assertion message.** Replace the
+   inline `"↻"` literal in `tab_bar.rs:71` with `icons.refresh()`. Thread `&IconSet`
+   through `TabBar::new()` (mirroring `new_session_dialog/mod.rs:162-175`). Update the
+   `target_selector.rs` call site. Surface the same glyph in `render_tabs_compact` when
+   the active tab's flag is set. Update test assertions in both files to use
+   `IconSet::default().refresh()` instead of the literal `"↻"`. Add a render test for
+   compact-mode glyph visibility. Add the diagnostic message to
+   `test_tab_bar_renders_bootable_refreshing_indicator`.
+
+5. **m1 + m3 + m5 + m7 + n1 + n3 — Polish bundle.** Add the symmetric
+   `BootableDevicesDiscovered` clearing test (m1). Add a comment in
+   `target_selector_state.rs` explaining `set_error()`'s asymmetric clearing (m3). Add
+   a comment near the `refreshing = true` write in `navigation.rs` explaining the
+   close+reopen race (m5). Collapse the dead `if/else` in
+   `handle_close_new_session_dialog` to a single `state.ui_mode = UiMode::Normal`,
+   removing the misleading "stay in startup mode" comment (m7). Multi-line the
+   `RefreshDevicesAndBootableBackground` enum variant with a `///` doc on `flutter` (n1).
+   Capture `cached_devices.len()` to a local before `.clone()` for clarity (n3).
+
+**Measurable Outcomes:**
+
+- Nerd Fonts users see the Nerd Font refresh glyph; Unicode users see `↻`.
+- Compact mode shows a refresh indicator when a tab's flag is set.
+- All cleanup items addressed without changing behaviour.
+- `cargo test --workspace --lib && cargo clippy --workspace --lib -- -D warnings` clean.
+
+---
+
+## Edge Cases & Risks
+
+### Background failure during cache-miss foreground discovery
+- **Scenario:** `DiscoverDevicesAndBootable` runs; the connected discovery fails (foreground)
+  while the bootable discovery completes (background).
+- **Behavior:** the foreground failure goes through the `is_background: false` arm,
+  hits `set_error()`, clears `loading` and `refreshing`. The bootable discovery completes
+  normally. Both behaviours are pre-existing and correct.
+
+### Compact mode glyph crowding
+- **Risk:** appending ` ↻` to a compact-mode tab label may push the line over its row width
+  on very narrow terminals.
+- **Mitigation:** the compact rendering is centered; minor truncation by ratatui is
+  acceptable. Indicator is a low-priority cue. If needed, the implementation can use a
+  single-character glyph without the leading space.
+
+### Test reliance on the literal `"↻"`
+- **Risk:** existing test assertions match `"↻"`. After routing through `IconSet`, the
+  exact resolved glyph depends on `IconMode`. Tests must use `IconSet::default()` (which
+  is `Unicode` per `icons.rs:79`) so the literal `"↻"` still appears in the rendered
+  output during tests.
+- **Mitigation:** Task 04 explicitly uses `IconSet::default()` in its test setup. No
+  test breakage expected.
+
+---
+
+## Out of Scope
+
+- Generic multi-action `UpdateResult` redesign. The `DiscoverDevicesAndBootable` variant
+  is a narrow workaround mirroring `RefreshDevicesAndBootableBackground`; the broader
+  design question is parked.
+- Moving `calculate_scroll_offset` to `fdemon-core` (m9, pre-existing TODO at
+  `target_selector_state.rs:455`).
+- Indicator-on-inactive-tab semantic change (m11). The implementation matches the parent
+  plan's Phase 2 §1 ("Show the indicator on both tabs simultaneously when both are
+  refreshing") and the user has confirmed keeping that behaviour.
+- Adding a real `BootableDiscoveryFailed` message variant to surface bootable errors. The
+  current `unwrap_or_default()` in `spawn_bootable_device_discovery` silently hides
+  failures — that's a separate UX decision and is not blocking.
+
+---
+
+## Success Criteria
+
+### Phase 1 Complete When:
+- [ ] `Message::DeviceDiscoveryFailed { is_background: true }` clears
+      `target_selector.refreshing` when the dialog is visible.
+- [ ] Test `test_background_device_discovery_failure_clears_refreshing` passes.
+- [ ] `get_cached_bootable_devices()` returns
+      `Option<(&Vec<IosSimulator>, &Vec<AndroidAvd>)>`.
+- [ ] All existing bootable cache tests pass.
+- [ ] `UpdateAction::DiscoverDevicesAndBootable { flutter }` exists; cache-miss fallback
+      dispatches it.
+- [ ] Test `test_open_dialog_no_caches_dispatches_combined_discovery` passes.
+- [ ] BUG.md line 191 in the parent plan is corrected.
+
+### Phase 2 Complete When:
+- [ ] `tab_bar.rs` calls `icons.refresh()` (no inline `↻` literal).
+- [ ] `TabBar::new()` accepts `&IconSet`.
+- [ ] Compact mode renders the refresh glyph when an active tab's flag is set.
+- [ ] Test assertions in `tab_bar.rs` and `target_selector.rs` reference
+      `IconSet::default().refresh()` rather than `"↻"`.
+- [ ] All polish items applied (m1, m3, m5, m7, n1-n3).
+- [ ] `cargo fmt --all && cargo check --workspace && cargo test --workspace --lib && cargo clippy --workspace --lib -- -D warnings` clean.
+
+---
+
+## Task Dependency Graph
+
+```
+Phase 1
+├── 01-clear-refreshing-on-bg-failure   (handler/update.rs + tests + BUG.md doc fix)
+├── 02-bootable-accessor-refs           (state.rs + navigation.rs single-call refactor)
+└── 03-discover-and-bootable-action     (handler/mod.rs + actions/mod.rs + navigation.rs cache-miss)
+        depends on: 02 (file overlap on navigation.rs)
+
+Phase 2
+├── 04-icon-routing-and-compact         (tab_bar.rs + target_selector.rs)
+└── 05-polish-bundle                    (handler/tests.rs + handler/mod.rs + navigation.rs + target_selector_state.rs)
+```
+
+---
+
+## Milestone Deliverable
+
+When both phases are complete:
+
+- The `↻` indicator clears on every discovery outcome — success, foreground failure,
+  and **background failure**.
+- Both connected and bootable lists are refreshed on every dialog open, regardless of
+  cache state — matching the parent plan's stated milestone.
+- The bootable cache accessor returns references with no hidden allocations.
+- The refresh glyph respects the user's `IconMode` setting (Unicode vs Nerd Fonts).
+- The compact-mode tab bar surfaces the indicator alongside the full-mode tab bar.
+- The parent plan's `BUG.md` mitigation note is factually correct.

--- a/workflow/plans/bugs/device-cache-followup/TASKS.md
+++ b/workflow/plans/bugs/device-cache-followup/TASKS.md
@@ -1,0 +1,88 @@
+# Tasks: Device Cache No-TTL Review Follow-up
+
+Plan: [BUG.md](BUG.md)
+Source review: [REVIEW.md](../../../reviews/bugs/device-cache-no-ttl/REVIEW.md)
+
+---
+
+## Wave 1 — Independent foundation tasks
+
+| ID | Task | Depends on | Files Modified (Write) | Files Read |
+|---|---|---|---|---|
+| 01 | [Clear `refreshing` on background failure](tasks/01-clear-refreshing-on-bg-failure.md) | — | `crates/fdemon-app/src/handler/update.rs`, `crates/fdemon-app/src/handler/tests.rs`, `workflow/plans/bugs/device-cache-no-ttl/BUG.md` | `target_selector_state.rs`, `state.rs` |
+| 02 | [Reference-returning bootable accessor](tasks/02-bootable-accessor-refs.md) | — | `crates/fdemon-app/src/state.rs`, `crates/fdemon-app/src/handler/new_session/navigation.rs` | `target_selector_state.rs` |
+
+## Wave 2 — Cache-miss wiring (sequential after Wave 1)
+
+| ID | Task | Depends on | Files Modified (Write) | Files Read |
+|---|---|---|---|---|
+| 03 | [`DiscoverDevicesAndBootable` action + cache-miss wiring](tasks/03-discover-and-bootable-action.md) | 02 | `crates/fdemon-app/src/handler/mod.rs`, `crates/fdemon-app/src/actions/mod.rs`, `crates/fdemon-app/src/handler/new_session/navigation.rs` | `spawn.rs`, `state.rs` |
+
+## Wave 3 — Polish (parallel after Wave 2)
+
+| ID | Task | Depends on | Files Modified (Write) | Files Read |
+|---|---|---|---|---|
+| 04 | [Icon routing + compact-mode glyph](tasks/04-icon-routing-and-compact.md) | — | `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs`, `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | `theme/icons.rs`, `widgets/new_session_dialog/mod.rs` |
+| 05 | [Polish bundle](tasks/05-polish-bundle.md) | — | `crates/fdemon-app/src/handler/tests.rs`, `crates/fdemon-app/src/handler/mod.rs`, `crates/fdemon-app/src/handler/new_session/navigation.rs`, `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | — |
+
+---
+
+## File Overlap Analysis
+
+### Wave 1 — Overlap Matrix
+
+| Pair | Shared Write Files | Strategy |
+|---|---|---|
+| 01 ↔ 02 | none | Parallel (worktree) |
+
+Wave 1 has zero write-file overlap → tasks 01 and 02 can run in parallel worktrees.
+
+### Wave 2 — Single Task
+
+Wave 2 contains a single task (03), so there is no parallelism question. Task 03 writes
+`navigation.rs`, which is also written by task 02; this is why 03 depends on 02 and runs
+sequentially after Wave 1 has merged.
+
+### Wave 3 — Overlap Matrix
+
+| Pair | Shared Write Files | Strategy |
+|---|---|---|
+| 04 ↔ 05 | none | Parallel (worktree) |
+
+Wave 3 has zero write-file overlap → tasks 04 and 05 can run in parallel worktrees once
+Waves 1 and 2 have merged.
+
+### Cross-wave file overlap (informational)
+
+These files are written across multiple tasks. Wave ordering ensures sequential merges,
+so there is no merge-conflict risk:
+
+- `handler/new_session/navigation.rs`: written by 02 (Wave 1) → 03 (Wave 2) → 05 (Wave 3)
+- `handler/mod.rs`: written by 03 (Wave 2) → 05 (Wave 3)
+- `handler/tests.rs`: written by 01 (Wave 1) → 05 (Wave 3)
+- `target_selector.rs`: written by 04 (Wave 3) only
+
+### Read-only overlap (informational, no conflict risk)
+
+- Task 01 reads `target_selector_state.rs` and `state.rs` (informational).
+- Task 03 reads `state.rs` (modified by 02 — Wave 2 ordering ensures the post-02 state).
+- Task 04 reads `theme/icons.rs` (unmodified) and `widgets/new_session_dialog/mod.rs` (for
+  the existing `&'a IconSet` pattern).
+
+---
+
+## Dispatch Order Summary
+
+```
+Wave 1 (parallel worktrees):  01, 02
+        ↓
+Wave 2 (single task, sequential): 03
+        ↓
+Wave 3 (parallel worktrees):  04, 05
+```
+
+All tasks: `Agent: implementor`. No core docs (`docs/ARCHITECTURE.md`,
+`docs/CODE_STANDARDS.md`, `docs/DEVELOPMENT.md`) require updates — this is a localized
+follow-up bug fix. The only documentation change is a one-line correction to the parent
+plan's `BUG.md`, applied as part of task 01 (no `doc_maintainer` routing needed for plan
+docs under `workflow/`).

--- a/workflow/plans/bugs/device-cache-followup/TASKS.md
+++ b/workflow/plans/bugs/device-cache-followup/TASKS.md
@@ -9,21 +9,21 @@ Source review: [REVIEW.md](../../../reviews/bugs/device-cache-no-ttl/REVIEW.md)
 
 | ID | Task | Depends on | Files Modified (Write) | Files Read |
 |---|---|---|---|---|
-| 01 | [Clear `refreshing` on background failure](tasks/01-clear-refreshing-on-bg-failure.md) | — | `crates/fdemon-app/src/handler/update.rs`, `crates/fdemon-app/src/handler/tests.rs`, `workflow/plans/bugs/device-cache-no-ttl/BUG.md` | `target_selector_state.rs`, `state.rs` |
-| 02 | [Reference-returning bootable accessor](tasks/02-bootable-accessor-refs.md) | — | `crates/fdemon-app/src/state.rs`, `crates/fdemon-app/src/handler/new_session/navigation.rs` | `target_selector_state.rs` |
+| 01 | [x] [Clear `refreshing` on background failure](tasks/01-clear-refreshing-on-bg-failure.md) — Done ✅ | — | `crates/fdemon-app/src/handler/update.rs`, `crates/fdemon-app/src/handler/tests.rs`, `workflow/plans/bugs/device-cache-no-ttl/BUG.md` | `target_selector_state.rs`, `state.rs` |
+| 02 | [x] [Reference-returning bootable accessor](tasks/02-bootable-accessor-refs.md) — Done ✅ | — | `crates/fdemon-app/src/state.rs`, `crates/fdemon-app/src/handler/new_session/navigation.rs` | `target_selector_state.rs` |
 
 ## Wave 2 — Cache-miss wiring (sequential after Wave 1)
 
 | ID | Task | Depends on | Files Modified (Write) | Files Read |
 |---|---|---|---|---|
-| 03 | [`DiscoverDevicesAndBootable` action + cache-miss wiring](tasks/03-discover-and-bootable-action.md) | 02 | `crates/fdemon-app/src/handler/mod.rs`, `crates/fdemon-app/src/actions/mod.rs`, `crates/fdemon-app/src/handler/new_session/navigation.rs` | `spawn.rs`, `state.rs` |
+| 03 | [x] [`DiscoverDevicesAndBootable` action + cache-miss wiring](tasks/03-discover-and-bootable-action.md) — Done ✅ | 02 | `crates/fdemon-app/src/handler/mod.rs`, `crates/fdemon-app/src/actions/mod.rs`, `crates/fdemon-app/src/handler/new_session/navigation.rs` | `spawn.rs`, `state.rs` |
 
 ## Wave 3 — Polish (parallel after Wave 2)
 
 | ID | Task | Depends on | Files Modified (Write) | Files Read |
 |---|---|---|---|---|
-| 04 | [Icon routing + compact-mode glyph](tasks/04-icon-routing-and-compact.md) | — | `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs`, `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | `theme/icons.rs`, `widgets/new_session_dialog/mod.rs` |
-| 05 | [Polish bundle](tasks/05-polish-bundle.md) | — | `crates/fdemon-app/src/handler/tests.rs`, `crates/fdemon-app/src/handler/mod.rs`, `crates/fdemon-app/src/handler/new_session/navigation.rs`, `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | — |
+| 04 | [x] [Icon routing + compact-mode glyph](tasks/04-icon-routing-and-compact.md) — Done ✅ | — | `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs`, `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | `theme/icons.rs`, `widgets/new_session_dialog/mod.rs` |
+| 05 | [x] [Polish bundle](tasks/05-polish-bundle.md) — Done ✅ | — | `crates/fdemon-app/src/handler/tests.rs`, `crates/fdemon-app/src/handler/mod.rs`, `crates/fdemon-app/src/handler/new_session/navigation.rs`, `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | — |
 
 ---
 

--- a/workflow/plans/bugs/device-cache-followup/tasks/01-clear-refreshing-on-bg-failure.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/01-clear-refreshing-on-bg-failure.md
@@ -137,3 +137,35 @@ incorrectly claims `set_error()` handles this case — that line needs to be cor
 - Reworking the `is_background` boolean into a typed enum.
 - Changing the `set_error()` implementation in `target_selector_state.rs` (handled in
   task 05's polish bundle).
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** main
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/handler/update.rs` | Added `refreshing = false` clear in the `is_background: true` branch of `DeviceDiscoveryFailed`, guarded by `NewSessionDialog || Startup` UI mode check |
+| `crates/fdemon-app/src/handler/tests.rs` | Added `test_background_device_discovery_failure_clears_refreshing` test immediately after `test_devices_discovered_clears_refreshing` |
+| `workflow/plans/bugs/device-cache-no-ttl/BUG.md` | Corrected the "Cache Becoming Severely Stale" mitigation paragraph to accurately describe both foreground and background clearing paths |
+
+### Notable Decisions/Tradeoffs
+
+1. **`bootable_refreshing` untouched**: The task explicitly requires not clearing `bootable_refreshing` in this arm. The bootable discovery spawn swallows errors via `unwrap_or_default()` and never sends `DeviceDiscoveryFailed`, so touching that flag here would be incorrect and misleading.
+
+2. **UI mode guard mirrors foreground branch**: The condition `UiMode::NewSessionDialog || UiMode::Startup` exactly mirrors the existing foreground guard, so the behaviour is symmetric — both branches only touch dialog state when the dialog is actually visible.
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed (auto-formatted update.rs whitespace)
+- `cargo check -p fdemon-app` - Passed
+- `cargo test -p fdemon-app --lib` - Passed (1893 tests, 0 failed)
+- `cargo clippy -p fdemon-app --lib -- -D warnings` - Passed (no warnings)
+
+### Risks/Limitations
+
+1. **No risk**: The change is minimal and surgical — one boolean assignment behind an existing UI-mode guard in a failure path that previously did nothing useful for the flag.

--- a/workflow/plans/bugs/device-cache-followup/tasks/01-clear-refreshing-on-bg-failure.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/01-clear-refreshing-on-bg-failure.md
@@ -1,0 +1,139 @@
+# Task 01 — Clear `refreshing` on Background Discovery Failure
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** none
+**Files Modified (Write):**
+- `crates/fdemon-app/src/handler/update.rs`
+- `crates/fdemon-app/src/handler/tests.rs`
+- `workflow/plans/bugs/device-cache-no-ttl/BUG.md`
+
+---
+
+## Goal
+
+Fix the Critical issue from
+[`workflow/reviews/bugs/device-cache-no-ttl/REVIEW.md`](../../../../reviews/bugs/device-cache-no-ttl/REVIEW.md):
+when `Message::DeviceDiscoveryFailed { is_background: true }` arrives, clear
+`target_selector.refreshing` so the `↻` indicator does not stay stuck on the Connected
+tab. Three reviewers (`bug_fix_reviewer`, `architecture_enforcer`,
+`logic_reasoning_checker`) flagged this independently.
+
+## Context
+
+The new `RefreshDevicesAndBootableBackground` action sends connected-discovery failures
+through `is_background: true` (`crates/fdemon-app/src/spawn.rs:45-68`). The current handler
+arm at `update.rs:409-412` only logs:
+
+```rust
+if is_background {
+    tracing::warn!("Background device refresh failed: {}", error);
+} else {
+    if state.ui_mode == UiMode::Startup || state.ui_mode == UiMode::NewSessionDialog {
+        state.new_session_dialog_state.target_selector.set_error(error.clone());
+    }
+    tracing::error!("Device discovery failed: {}", error);
+}
+```
+
+`set_error()` (which clears `refreshing`) is reached only via the foreground branch.
+Background failures leave the flag set indefinitely.
+
+The parent plan's mitigation note (`workflow/plans/bugs/device-cache-no-ttl/BUG.md:191`)
+incorrectly claims `set_error()` handles this case — that line needs to be corrected.
+
+## Steps
+
+1. Open `crates/fdemon-app/src/handler/update.rs`. Locate the
+   `Message::DeviceDiscoveryFailed { error, is_background }` arm (around line 405).
+
+2. In the `is_background` branch, after the existing `tracing::warn!`, clear `refreshing`
+   when the new-session dialog is visible:
+
+   ```rust
+   if is_background {
+       tracing::warn!("Background device refresh failed: {}", error);
+       if state.ui_mode == UiMode::NewSessionDialog || state.ui_mode == UiMode::Startup {
+           state.new_session_dialog_state.target_selector.refreshing = false;
+       }
+   } else {
+       // ... existing foreground branch unchanged
+   }
+   ```
+
+   Notes:
+   - Mirror the existing `state.ui_mode == UiMode::Startup || state.ui_mode == UiMode::NewSessionDialog`
+     guard used by the foreground branch.
+   - Do NOT clear `bootable_refreshing` here. The bootable spawn never sends
+     `DeviceDiscoveryFailed`; its errors are swallowed via `unwrap_or_default()` in
+     `spawn_bootable_device_discovery`. Touching `bootable_refreshing` here would be
+     incorrect — see the parent plan's `BUG.md` for context.
+   - Use `tracing::warn!` only (don't elevate to `error!`) — background failures are
+     non-fatal; the user still sees the cached list.
+
+3. Add an integration test in `crates/fdemon-app/src/handler/tests.rs`. Place it near the
+   existing `test_devices_discovered_clears_refreshing` test (recently added):
+
+   ```rust
+   #[test]
+   fn test_background_device_discovery_failure_clears_refreshing() {
+       let mut state = AppState::new();
+       state.show_new_session_dialog(LoadedConfigs::default());
+       state.set_device_cache(vec![test_device("dev1", "Device 1")]);
+       state.new_session_dialog_state.target_selector.refreshing = true;
+
+       let _ = handler::update(
+           &mut state,
+           Message::DeviceDiscoveryFailed {
+               error: "transient flutter devices error".to_string(),
+               is_background: true,
+           },
+       );
+
+       assert!(
+           !state.new_session_dialog_state.target_selector.refreshing,
+           "background failure must clear the refreshing flag"
+       );
+   }
+   ```
+
+   Use the `test_device(...)` helper if it exists in scope (mirror the existing
+   `test_devices_discovered_clears_refreshing` test for the exact import / helper style).
+
+4. Update the parent plan's BUG.md. Open
+   `workflow/plans/bugs/device-cache-no-ttl/BUG.md`, find the "Cache Becoming Severely
+   Stale" subsection (around line 187-193), and replace the inaccurate claim about
+   `set_error()` clearing `refreshing` with an accurate description. Suggested rewording:
+
+   > **Mitigation:** every dialog open triggers a background refresh, and the discovery
+   > failure path (`Message::DeviceDiscoveryFailed`) clears the `refreshing` indicator on
+   > both the foreground branch (via `set_error()`) and the background branch (via a
+   > direct flag clear). Background failures (`is_background: true`) are logged at warn
+   > level only — the user still sees the previous devices, which is the desired UX.
+
+5. Run the verification commands:
+   - `cargo fmt --all`
+   - `cargo check -p fdemon-app`
+   - `cargo test -p fdemon-app --lib`
+   - `cargo clippy -p fdemon-app --lib -- -D warnings`
+
+## Acceptance Criteria
+
+- [ ] `update.rs` `is_background: true` arm clears
+      `state.new_session_dialog_state.target_selector.refreshing` when the dialog or
+      startup is visible.
+- [ ] `bootable_refreshing` is **not** modified by this arm (see Notes above).
+- [ ] New test `test_background_device_discovery_failure_clears_refreshing` is present
+      in `handler/tests.rs` and passes.
+- [ ] Parent plan's `BUG.md` "Cache Becoming Severely Stale" mitigation paragraph no
+      longer claims `set_error()` is the sole clearing path.
+- [ ] `cargo test -p fdemon-app --lib` passes (no regressions).
+- [ ] `cargo clippy -p fdemon-app --lib -- -D warnings` clean.
+
+## Out of Scope
+
+- Adding a `BootableDiscoveryFailed` message variant (parent plan's bootable spawn
+  swallows errors; surfacing them is a separate UX decision).
+- Reworking the `is_background` boolean into a typed enum.
+- Changing the `set_error()` implementation in `target_selector_state.rs` (handled in
+  task 05's polish bundle).

--- a/workflow/plans/bugs/device-cache-followup/tasks/02-bootable-accessor-refs.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/02-bootable-accessor-refs.md
@@ -1,0 +1,119 @@
+# Task 02 — Reference-Returning Bootable Cache Accessor
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** none
+**Files Modified (Write):**
+- `crates/fdemon-app/src/state.rs`
+- `crates/fdemon-app/src/handler/new_session/navigation.rs`
+
+---
+
+## Goal
+
+Fix Major issue M2 from the review: `get_cached_bootable_devices()` currently clones two
+`Vec`s on every call, asymmetric with `get_cached_devices()` which returns a borrow. The
+clone should live at the single call site, mirroring the connected-device pattern.
+
+## Context
+
+Current accessor at `crates/fdemon-app/src/state.rs:1261-1266`:
+
+```rust
+pub fn get_cached_bootable_devices(&self) -> Option<(Vec<IosSimulator>, Vec<AndroidAvd>)> {
+    match (&self.ios_simulators_cache, &self.android_avds_cache) {
+        (Some(sims), Some(avds)) => Some((sims.clone(), avds.clone())),
+        _ => None,
+    }
+}
+```
+
+Connected-device equivalent (post-Phase-1 of the parent plan):
+
+```rust
+pub fn get_cached_devices(&self) -> Option<&Vec<Device>> {
+    self.device_cache.as_ref()
+}
+```
+
+Sole caller of `get_cached_bootable_devices`: `crates/fdemon-app/src/handler/new_session/navigation.rs`,
+inside `handle_open_new_session_dialog`, around line 221-234. The result is destructured
+and forwarded to `set_bootable_devices(simulators, avds)` which takes ownership.
+
+## Steps
+
+1. Open `crates/fdemon-app/src/state.rs`. Update `get_cached_bootable_devices()` (around
+   line 1261):
+
+   ```rust
+   pub fn get_cached_bootable_devices(&self) -> Option<(&Vec<IosSimulator>, &Vec<AndroidAvd>)> {
+       match (&self.ios_simulators_cache, &self.android_avds_cache) {
+           (Some(sims), Some(avds)) => Some((sims, avds)),
+           _ => None,
+       }
+   }
+   ```
+
+   Update the doc comment to note that the caller is responsible for cloning if it needs
+   ownership (mirroring the `get_cached_devices` doc).
+
+2. Open `crates/fdemon-app/src/handler/new_session/navigation.rs`. Locate the
+   single caller (around line 221). The pattern currently looks like:
+
+   ```rust
+   if let Some((simulators, avds)) = state.get_cached_bootable_devices() {
+       // ... debug log
+       state.new_session_dialog_state
+           .target_selector
+           .set_bootable_devices(simulators, avds);
+       // ...
+   }
+   ```
+
+   Update to clone at the call site, mirroring how `cached_devices.clone()` is used
+   for the connected branch a few lines above:
+
+   ```rust
+   if let Some((simulators, avds)) = state.get_cached_bootable_devices() {
+       let simulators = simulators.clone();
+       let avds = avds.clone();
+       // ... debug log (use simulators.len() / avds.len() before the moves if needed)
+       state.new_session_dialog_state
+           .target_selector
+           .set_bootable_devices(simulators, avds);
+       // ...
+   }
+   ```
+
+   The borrow-checker may require capturing lengths into locals before the clones if the
+   debug log uses `.len()`. Check the current code and adjust accordingly.
+
+3. **Do not** change `set_bootable_devices` — it still takes ownership.
+
+4. **Do not** add new tests. This is a pure refactor; existing tests
+   (`test_open_dialog_uses_cached_devices`, `test_bootable_cache_*`, etc.) verify the
+   behavior is unchanged.
+
+5. Run verification:
+   - `cargo fmt --all`
+   - `cargo check -p fdemon-app`
+   - `cargo test -p fdemon-app --lib`
+   - `cargo clippy -p fdemon-app --lib -- -D warnings`
+
+## Acceptance Criteria
+
+- [ ] `get_cached_bootable_devices()` returns
+      `Option<(&Vec<IosSimulator>, &Vec<AndroidAvd>)>` with no `.clone()` inside.
+- [ ] Single call site in `navigation.rs` clones at the call site before forwarding to
+      `set_bootable_devices`.
+- [ ] No other call sites of `get_cached_bootable_devices()` exist (verify with grep).
+- [ ] Existing bootable cache tests pass without modification.
+- [ ] `cargo test -p fdemon-app --lib` passes (no regressions).
+- [ ] `cargo clippy -p fdemon-app --lib -- -D warnings` clean.
+
+## Out of Scope
+
+- Changing `set_bootable_devices` to borrow instead of own (its caller paths in update
+  handlers receive owned values from messages; ownership is correct there).
+- Restructuring the bootable cache fields themselves.
+- The cache-miss bootable discovery (handled in task 03).

--- a/workflow/plans/bugs/device-cache-followup/tasks/02-bootable-accessor-refs.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/02-bootable-accessor-refs.md
@@ -117,3 +117,34 @@ and forwarded to `set_bootable_devices(simulators, avds)` which takes ownership.
   handlers receive owned values from messages; ownership is correct there).
 - Restructuring the bootable cache fields themselves.
 - The cache-miss bootable discovery (handled in task 03).
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** main
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/state.rs` | Changed `get_cached_bootable_devices()` return type from `Option<(Vec<IosSimulator>, Vec<AndroidAvd>)>` to `Option<(&Vec<IosSimulator>, &Vec<AndroidAvd>)>`; removed `.clone()` calls inside the function; updated doc comment to note caller responsibility for cloning |
+| `crates/fdemon-app/src/handler/new_session/navigation.rs` | Added `let simulators = simulators.clone()` and `let avds = avds.clone()` at the call site inside `handle_open_new_session_dialog`, before forwarding to `set_bootable_devices` |
+
+### Notable Decisions/Tradeoffs
+
+1. **Clone placement**: The clones are inserted immediately after the `if let` binding (before the debug log), so `simulators.len()` and `avds.len()` in the debug log refer to the freshly-cloned owned values. This matches the semantics of the original code and avoids any re-borrowing issues.
+
+2. **No test changes**: The existing tests in `state.rs` (`test_get_cached_bootable_devices_valid`, `test_get_cached_bootable_devices_empty_when_not_set`) access the returned tuple via auto-deref, so they work unchanged with references.
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed (no formatting changes needed)
+- `cargo check -p fdemon-app` - Passed
+- `cargo test -p fdemon-app --lib` - Passed (1892 tests, 0 failures)
+- `cargo clippy -p fdemon-app --lib -- -D warnings` - Passed (no warnings)
+
+### Risks/Limitations
+
+1. **None**: Pure refactor with identical observable behavior. The borrow-checker enforces correctness at compile time.

--- a/workflow/plans/bugs/device-cache-followup/tasks/03-discover-and-bootable-action.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/03-discover-and-bootable-action.md
@@ -156,6 +156,41 @@ discovery so the user gets a proper loading indicator and surfaced errors.
 - [ ] `cargo test --workspace --lib` passes.
 - [ ] `cargo clippy --workspace --lib -- -D warnings` clean.
 
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** main
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/handler/mod.rs` | Added `DiscoverDevicesAndBootable { flutter: FlutterExecutable }` variant to `UpdateAction` enum with doc comment and field doc |
+| `crates/fdemon-app/src/actions/mod.rs` | Added match arm that calls `spawn_device_discovery(msg_tx.clone(), flutter)` and `spawn_bootable_device_discovery(msg_tx, tool_availability)` |
+| `crates/fdemon-app/src/handler/new_session/navigation.rs` | Updated cache-miss fallback to dispatch `DiscoverDevicesAndBootable`; updated doc comment; updated two existing tests; added new `test_open_dialog_no_caches_dispatches_combined_discovery` test |
+
+### Notable Decisions/Tradeoffs
+
+1. **Variant placement**: `DiscoverDevicesAndBootable` is placed immediately after `RefreshDevicesAndBootableBackground` in the enum, keeping the "combined" variants together for readability.
+2. **msg_tx.clone() pattern**: Mirrors the existing `RefreshDevicesAndBootableBackground` arm exactly — the first spawn gets a clone, the second consumes the original sender.
+3. **doc comment update**: Updated the doc comment on `handle_open_new_session_dialog` to reference the new action name rather than the old `DiscoverDevices` path.
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed
+- `cargo check --workspace` - Passed
+- `cargo test -p fdemon-app --lib` - Passed (1894 passed, 0 failed, 4 ignored)
+  - `test_open_dialog_no_caches_dispatches_combined_discovery` - ok
+  - `test_open_dialog_cache_miss_shows_loading` (updated assertion) - ok
+  - `test_open_dialog_no_caches_falls_back_to_loading` (updated assertion) - ok
+- `cargo clippy --workspace --lib -- -D warnings` - Passed (clean)
+
+### Risks/Limitations
+
+1. **Existing `DiscoverDevices` call sites**: Verified 6 other call sites all remain unaffected (engine startup, session lifecycle, target_selector pull-to-refresh) — none were in the cache-miss path.
+
 ## Out of Scope
 
 - Changing the existing `DiscoverDevices` variant (still used elsewhere — e.g., engine

--- a/workflow/plans/bugs/device-cache-followup/tasks/03-discover-and-bootable-action.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/03-discover-and-bootable-action.md
@@ -1,0 +1,165 @@
+# Task 03 — `DiscoverDevicesAndBootable` Action + Cache-Miss Wiring
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** 02 (file overlap on `navigation.rs`)
+**Files Modified (Write):**
+- `crates/fdemon-app/src/handler/mod.rs`
+- `crates/fdemon-app/src/actions/mod.rs`
+- `crates/fdemon-app/src/handler/new_session/navigation.rs`
+
+---
+
+## Goal
+
+Fix Major issue M1 from the review: when both caches are empty, the cache-miss fallback
+in `handle_open_new_session_dialog` dispatches only `UpdateAction::DiscoverDevices`, which
+spawns connected discovery only. The bootable list silently sits at its default loading
+state until the user manually switches tabs — contradicting the parent plan's milestone:
+"Both connected and bootable lists are refreshed on every dialog open."
+
+Add a new `UpdateAction::DiscoverDevicesAndBootable { flutter }` variant that runs
+foreground connected discovery + background bootable discovery in parallel, mirroring
+the existing `RefreshDevicesAndBootableBackground` pattern.
+
+## Context
+
+Cache-miss fallback at `crates/fdemon-app/src/handler/new_session/navigation.rs:258-261`:
+
+```rust
+state.new_session_dialog_state.target_selector.loading = true;
+return UpdateResult::action(UpdateAction::DiscoverDevices { flutter });
+```
+
+`DiscoverDevices` action handler at `crates/fdemon-app/src/actions/mod.rs:75-77`:
+
+```rust
+UpdateAction::DiscoverDevices { flutter } => {
+    spawn::spawn_device_discovery(msg_tx, flutter);
+}
+```
+
+The existing `RefreshDevicesAndBootableBackground` variant at lines 85-90 spawns both
+`spawn_device_discovery_background` (background) and `spawn_bootable_device_discovery`
+(background). We need the same parallel-spawn shape but with the foreground connected
+discovery so the user gets a proper loading indicator and surfaced errors.
+
+## Steps
+
+1. Open `crates/fdemon-app/src/handler/mod.rs`. Add a new variant to the `UpdateAction`
+   enum, placed near `RefreshDevicesAndBootableBackground` (around line 80):
+
+   ```rust
+   /// Foreground connected-device discovery + background bootable discovery in parallel.
+   /// Used by the new-session dialog cache-miss fallback so both tabs populate on
+   /// first dialog open even when no caches exist.
+   ///
+   /// `UpdateResult` carries a single action, so this combined variant is the cleanest
+   /// way to spawn both. Mirrors `RefreshDevicesAndBootableBackground` but uses the
+   /// foreground (loading-aware) connected spawn.
+   DiscoverDevicesAndBootable {
+       /// Flutter executable to use for both discovery tasks.
+       flutter: FlutterExecutable,
+   },
+   ```
+
+2. Open `crates/fdemon-app/src/actions/mod.rs`. Add a match arm for the new action,
+   placed near the existing `RefreshDevicesAndBootableBackground` arm (around line 85):
+
+   ```rust
+   UpdateAction::DiscoverDevicesAndBootable { flutter } => {
+       spawn::spawn_device_discovery(msg_tx.clone(), flutter);
+       spawn::spawn_bootable_device_discovery(msg_tx, tool_availability);
+   }
+   ```
+
+   Notes:
+   - Use `msg_tx.clone()` for the first spawn and let the second consume `msg_tx`
+     (mirrors the `RefreshDevicesAndBootableBackground` pattern at lines 85-90).
+   - `spawn_device_discovery` is the foreground variant (loading-aware, sends
+     `DevicesDiscovered` on success and `DeviceDiscoveryFailed { is_background: false }`
+     on failure).
+   - `spawn_bootable_device_discovery` is the same one used by the background refresh
+     (uses `tool_availability` for emulator/simulator listings).
+
+3. Open `crates/fdemon-app/src/handler/new_session/navigation.rs`. Locate the cache-miss
+   fallback in `handle_open_new_session_dialog` (around line 258-261). Replace:
+
+   ```rust
+   state.new_session_dialog_state.target_selector.loading = true;
+   return UpdateResult::action(UpdateAction::DiscoverDevices { flutter });
+   ```
+
+   with:
+
+   ```rust
+   state.new_session_dialog_state.target_selector.loading = true;
+   return UpdateResult::action(UpdateAction::DiscoverDevicesAndBootable { flutter });
+   ```
+
+   Do **not** change `loading = true` — the connected list still needs the foreground
+   loading indicator. The bootable tab keeps its default `bootable_loading = true` from
+   `TargetSelectorState::default()`, which `set_bootable_devices` will clear when the
+   background discovery completes.
+
+4. Add a unit test in the existing test module of `navigation.rs`. Place it near the
+   other `handle_open_new_session_dialog` cache-miss tests:
+
+   ```rust
+   #[test]
+   fn test_open_dialog_no_caches_dispatches_combined_discovery() {
+       let mut state = AppState::new();
+       // Both caches empty (default state)
+       assert!(state.device_cache.is_none());
+       assert!(state.ios_simulators_cache.is_none());
+       assert!(state.android_avds_cache.is_none());
+
+       let result = handle_open_new_session_dialog(&mut state, LoadedConfigs::default());
+
+       assert!(state.new_session_dialog_state.target_selector.loading,
+           "connected tab should show loading on cache miss");
+       assert!(matches!(
+           result.action,
+           Some(UpdateAction::DiscoverDevicesAndBootable { .. })
+       ), "cache miss should dispatch combined discovery, got {:?}", result.action);
+   }
+   ```
+
+   If the existing cache-miss test
+   (`test_open_dialog_cache_miss_shows_loading` or similar) asserted on
+   `UpdateAction::DiscoverDevices`, **update its assertion** to match the new variant —
+   do not delete it.
+
+5. Verify exhaustive matching in `actions/mod.rs` — if there is a wildcard `_ => {}` arm,
+   the new variant will silently fall through. Confirm via `cargo check`.
+
+6. Run verification:
+   - `cargo fmt --all`
+   - `cargo check --workspace`
+   - `cargo test -p fdemon-app --lib`
+   - `cargo clippy --workspace --lib -- -D warnings`
+
+## Acceptance Criteria
+
+- [ ] `UpdateAction::DiscoverDevicesAndBootable { flutter: FlutterExecutable }` exists in
+      `handler/mod.rs` with a doc comment and a `///` doc on the inner field.
+- [ ] `actions/mod.rs` has a match arm that spawns both
+      `spawn_device_discovery(msg_tx.clone(), flutter)` and
+      `spawn_bootable_device_discovery(msg_tx, tool_availability)`.
+- [ ] `navigation.rs` cache-miss fallback dispatches the new action instead of
+      `DiscoverDevices`.
+- [ ] New test `test_open_dialog_no_caches_dispatches_combined_discovery` is present and
+      passes.
+- [ ] Any existing cache-miss test that previously asserted on `DiscoverDevices` is
+      updated to match the new variant.
+- [ ] `cargo build --workspace` has no exhaustive-match warnings.
+- [ ] `cargo test --workspace --lib` passes.
+- [ ] `cargo clippy --workspace --lib -- -D warnings` clean.
+
+## Out of Scope
+
+- Changing the existing `DiscoverDevices` variant (still used elsewhere — e.g., engine
+  startup). Verify with grep that other call sites are unaffected.
+- Adding a generic multi-action `UpdateResult` mechanism (parent plan deferred this).
+- Surfacing bootable discovery errors as a real `BootableDiscoveryFailed` message.
+- Setting `bootable_loading = true` explicitly — the default state already has it set.

--- a/workflow/plans/bugs/device-cache-followup/tasks/04-icon-routing-and-compact.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/04-icon-routing-and-compact.md
@@ -1,0 +1,195 @@
+# Task 04 — Route `↻` Through `IconSet` + Compact-Mode Glyph
+
+**Agent:** implementor
+**Phase:** 2
+**Depends on:** none (Wave 3, after Wave 2 has merged)
+**Files Modified (Write):**
+- `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs`
+- `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs`
+
+---
+
+## Goal
+
+Fix Minor issues m2, m4, and nitpick n2:
+
+- **m2:** `tab_bar.rs:71` hardcodes the literal `"↻"`, bypassing
+  `IconSet::refresh()` (`crates/fdemon-tui/src/theme/icons.rs:96-101`) which already
+  resolves the correct glyph for both `IconMode::Unicode` and `IconMode::NerdFonts`.
+  Nerd Fonts users currently see the wrong glyph.
+- **m4:** `render_tabs_compact` in `target_selector.rs` does not surface the refresh
+  indicator. Users on short terminals get no visual cue that a background refresh is in
+  flight.
+- **n2:** `test_tab_bar_renders_bootable_refreshing_indicator` lacks the diagnostic
+  message its sister test has.
+
+## Context
+
+`IconSet::refresh()` already returns `"\u{21bb}"` (= `↻`) for `Unicode` and the Nerd
+Font equivalent for `NerdFonts`. The pattern for threading `&IconSet` into a widget is
+already established in `crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs:162,175`
+(`icons: &'a IconSet`).
+
+`TabBar::new()` currently takes 4 args (`active_tab, pane_focused, connected_refreshing,
+bootable_refreshing`). It will gain `icons: &IconSet` as a fifth.
+
+`render_tabs_compact` (around `target_selector.rs:208-251`) renders a single line of
+`Span`s wrapped in a `Paragraph`. Both `self.state.refreshing` and
+`self.state.bootable_refreshing` are accessible.
+
+`render_full` already calls `TabBar::new(self.state.active_tab, self.is_focused,
+self.state.refreshing, self.state.bootable_refreshing)`. The call site needs to gain
+`icons` — locate where `target_selector.rs` already receives or constructs an `IconSet`.
+
+## Steps
+
+1. **Update `TabBar::new()` signature** in `tab_bar.rs:27`. Add a final `icons: &'a IconSet`
+   parameter; introduce a lifetime `'a` on the struct or accept an owned `IconSet` (cheap
+   to clone — it's a thin wrapper over an enum). Pick whichever fits the existing pattern
+   in `mod.rs:162`. Suggested:
+
+   ```rust
+   pub struct TabBar<'a> {
+       active_tab: TargetTab,
+       pane_focused: bool,
+       connected_refreshing: bool,
+       bootable_refreshing: bool,
+       icons: &'a IconSet,
+   }
+
+   impl<'a> TabBar<'a> {
+       pub fn new(
+           active_tab: TargetTab,
+           pane_focused: bool,
+           connected_refreshing: bool,
+           bootable_refreshing: bool,
+           icons: &'a IconSet,
+       ) -> Self {
+           Self { active_tab, pane_focused, connected_refreshing, bootable_refreshing, icons }
+       }
+   }
+   ```
+
+   Add `use crate::theme::icons::IconSet;` if not already imported.
+
+2. **Replace the inline `"↻"` literal** in the render loop (around line 71). Replace:
+
+   ```rust
+   let label = if refreshing {
+       format!("{} ↻", tab.label())
+   } else {
+       tab.label().to_string()
+   };
+   ```
+
+   with:
+
+   ```rust
+   let label = if refreshing {
+       format!("{} {}", tab.label(), self.icons.refresh())
+   } else {
+       tab.label().to_string()
+   };
+   ```
+
+3. **Update `target_selector.rs` `render_full`** to pass `icons` into `TabBar::new()`.
+   Locate the call (around line 92) and append the icons argument. The icons reference
+   should already be reachable via the surrounding `render` / widget context — check
+   `target_selector.rs` for existing `&IconSet` or `IconSet` access; if none, accept it
+   as a parameter on `TargetSelector` (mirror the pattern from `device_list.rs:64,236`
+   which holds `icons: IconSet` and exposes `set_icon_mode`). Pick whichever style fits
+   the existing call hierarchy with the smallest churn.
+
+4. **Update `render_tabs_compact`** in `target_selector.rs` (around line 208-251). After
+   building each tab's `Span`s, append a small space + the refresh glyph when its flag is
+   set. Pseudocode:
+
+   ```rust
+   let connected_label = if self.state.refreshing {
+       format!("[1 {} {}]", connected_text, icons.refresh())
+   } else {
+       format!("[1 {}]", connected_text)
+   };
+   ```
+
+   Mirror the existing active/inactive styling. Keep changes minimal — the `↻` is a
+   secondary cue, not a layout element.
+
+5. **Update existing test assertions** in both `tab_bar.rs` and `target_selector.rs`.
+   Replace literal `"↻"` checks with assertions that resolve the glyph through
+   `IconSet::default()`. Example pattern:
+
+   ```rust
+   let icons = IconSet::default(); // = IconMode::Unicode → "↻"
+   let glyph = icons.refresh();
+   assert!(rendered.contains(glyph), "expected refresh glyph, got: {rendered}");
+   ```
+
+   Update calls to `TabBar::new(...)` in tests (currently 4-arg) to pass `&icons` as the
+   fifth argument. Search for all occurrences:
+
+   ```bash
+   grep -n "TabBar::new" crates/fdemon-tui/src/widgets/new_session_dialog/
+   ```
+
+6. **Add a compact-mode render test** in `target_selector.rs` (place near the existing
+   `test_target_selector_renders_refreshing_glyph_when_state_set` from the parent plan):
+
+   ```rust
+   #[test]
+   fn test_target_selector_compact_renders_refreshing_glyph() {
+       // Use a height < MIN_EXPANDED_HEIGHT to force compact mode
+       let area = Rect::new(0, 0, 40, 6);
+       let mut state = TargetSelectorState::default();
+       state.set_connected_devices(vec![test_device("dev1", "Device 1")]);
+       state.refreshing = true;
+       state.active_tab = TargetTab::Connected;
+
+       let icons = IconSet::default();
+       let rendered = render_to_string(/* construct TargetSelector with state, icons, area */);
+
+       assert!(rendered.contains(icons.refresh()),
+           "compact mode should show refresh glyph when active tab is refreshing");
+   }
+   ```
+
+   Use the same render-to-string helper that the existing compact-mode tests use (search
+   for `render_compact` test patterns).
+
+7. **Add diagnostic message** to `test_tab_bar_renders_bootable_refreshing_indicator`
+   (n2). Mirror the format used by `test_tab_bar_renders_connected_refreshing_indicator`:
+
+   ```rust
+   assert!(rendered.contains(glyph),
+       "expected refresh glyph on Bootable tab, got: {rendered}");
+   ```
+
+8. Run verification:
+   - `cargo fmt --all`
+   - `cargo check -p fdemon-tui`
+   - `cargo test -p fdemon-tui --lib`
+   - `cargo clippy -p fdemon-tui --lib -- -D warnings`
+
+## Acceptance Criteria
+
+- [ ] `tab_bar.rs:71` no longer contains the inline literal `"↻"`; uses
+      `self.icons.refresh()` instead.
+- [ ] `TabBar::new()` accepts `&IconSet` as a fifth parameter.
+- [ ] `target_selector.rs::render_full` passes `&IconSet` into `TabBar::new()`.
+- [ ] `render_tabs_compact` surfaces the refresh glyph when the active tab's flag is set.
+- [ ] All existing test assertions in `tab_bar.rs` and `target_selector.rs` use
+      `IconSet::default().refresh()` (or equivalent) instead of literal `"↻"`.
+- [ ] All `TabBar::new(...)` test call sites updated to include the icons argument.
+- [ ] New test `test_target_selector_compact_renders_refreshing_glyph` is present and
+      passes.
+- [ ] `test_tab_bar_renders_bootable_refreshing_indicator` has a diagnostic message on
+      its assertion.
+- [ ] `cargo test -p fdemon-tui --lib` passes (no regressions).
+- [ ] `cargo clippy -p fdemon-tui --lib -- -D warnings` clean.
+
+## Out of Scope
+
+- Changing `IconSet` itself or the resolved glyphs.
+- Plumbing `IconSet` through other widgets that don't currently have it.
+- Visual restyling of the indicator (color, dim, etc.) beyond the existing approach.
+- The polish bundle items (handled in task 05).

--- a/workflow/plans/bugs/device-cache-followup/tasks/04-icon-routing-and-compact.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/04-icon-routing-and-compact.md
@@ -193,3 +193,34 @@ self.state.refreshing, self.state.bootable_refreshing)`. The call site needs to 
 - Plumbing `IconSet` through other widgets that don't currently have it.
 - Visual restyling of the indicator (color, dim, etc.) beyond the existing approach.
 - The polish bundle items (handled in task 05).
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-af9cd63bac5de0327
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs` | Added `'a` lifetime + `icons: &'a IconSet` field to `TabBar`; updated `new()` signature; replaced `"↻"` literal with `self.icons.refresh()`; updated all 6 test `TabBar::new()` call sites to pass `&icons`; updated glyph assertions to use `icons.refresh()` instead of literal; added diagnostic message to bootable indicator test |
+| `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | Added `icons: IconSet` (owned, Copy) field to `TargetSelector`; added `.icons()` builder method; updated `render_full` to pass `&self.icons` into `TabBar::new()`; updated `render_tabs_compact` to append refresh glyph when active tab's flag is set; updated 3 existing test assertions to use `IconSet::default().refresh()` instead of literal `"↻"`; added new `test_target_selector_compact_renders_refreshing_glyph` test |
+
+### Notable Decisions/Tradeoffs
+
+1. **Owned `IconSet` in `TargetSelector` vs reference**: Used an owned `IconSet` (which is `Copy + Clone`, just wraps an enum) rather than a reference to avoid lifetime proliferation in the existing API. This keeps `TargetSelector::new()` signature unchanged; callers can opt into Nerd Font glyphs via the `.icons()` builder. The `mod.rs` call sites were not updated since they don't yet plumb `&IconSet` through (tracked as a future improvement if desired).
+
+2. **Compact mode label as `String` not `&'static str`**: The `render_tabs_compact` labels changed from `&'static str` to `String` to allow dynamic formatting with the refresh glyph. `Span::styled` accepts `Into<Cow<'static, str>>` which accepts `String`, so this works without changes to the ratatui API usage.
+
+### Testing Performed
+
+- `cargo fmt --all` — Passed
+- `cargo check -p fdemon-tui` — Passed
+- `cargo test -p fdemon-tui --lib` — Passed (876 tests, 0 failed)
+- `cargo clippy -p fdemon-tui --lib -- -D warnings` — Clean
+
+### Risks/Limitations
+
+1. **`TargetSelector` in `mod.rs` still uses `IconSet::default()`**: The `NewSessionDialog` has `self.icons` available but the two `TargetSelector::new()` call sites in `mod.rs` don't chain `.icons(*self.icons)`. The widget will work correctly for Unicode mode (the default) but Nerd Font users won't see the NF glyph in the tab bar when rendered through `NewSessionDialog`. A follow-up could add `.icons(*self.icons)` at those two call sites — but that is out of scope per task definition ("smallest churn").

--- a/workflow/plans/bugs/device-cache-followup/tasks/05-polish-bundle.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/05-polish-bundle.md
@@ -1,0 +1,191 @@
+# Task 05 — Polish Bundle (m1, m3, m5, m7, n1, n3)
+
+**Agent:** implementor
+**Phase:** 2
+**Depends on:** none (Wave 3, after Wave 2 has merged)
+**Files Modified (Write):**
+- `crates/fdemon-app/src/handler/tests.rs`
+- `crates/fdemon-app/src/handler/mod.rs`
+- `crates/fdemon-app/src/handler/new_session/navigation.rs`
+- `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs`
+
+---
+
+## Goal
+
+Apply the minor cleanups bundled together because they each touch only a few lines and
+land naturally in adjacent files.
+
+| Item | Where | What |
+|---|---|---|
+| m1 | `handler/tests.rs` | Symmetric `BootableDevicesDiscovered` clearing test |
+| m3 | `target_selector_state.rs` | Comment on `set_error()` asymmetric clearing |
+| m5 | `navigation.rs` | Comment on close+reopen race near `refreshing = true` |
+| m7 | `navigation.rs` | Collapse dead `if/else` in `handle_close_new_session_dialog` |
+| n1 | `handler/mod.rs` | Multi-line `RefreshDevicesAndBootableBackground` doc |
+| n3 | `navigation.rs` | Capture `cached_devices.len()` to a local before `.clone()` |
+
+## Steps
+
+### m1 — Symmetric bootable test
+
+Open `crates/fdemon-app/src/handler/tests.rs`. Find the existing
+`test_devices_discovered_clears_refreshing` test (added during the parent plan's task 04).
+Add a sibling test below it:
+
+```rust
+#[test]
+fn test_bootable_devices_discovered_clears_bootable_refreshing() {
+    let mut state = AppState::new();
+    state.show_new_session_dialog(LoadedConfigs::default());
+    state.new_session_dialog_state.target_selector.bootable_refreshing = true;
+
+    let _ = handler::update(
+        &mut state,
+        Message::BootableDevicesDiscovered {
+            ios_simulators: vec![],
+            android_avds: vec![],
+        },
+    );
+
+    assert!(
+        !state.new_session_dialog_state.target_selector.bootable_refreshing,
+        "BootableDevicesDiscovered must clear the bootable_refreshing flag"
+    );
+}
+```
+
+Match the imports / scaffolding the existing test uses.
+
+### m3 — Comment on `set_error()` asymmetric clearing
+
+Open `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs`. Find
+`set_error()` (around line 271-276). Add a doc comment above the function (or an inline
+comment) explaining why only `refreshing` is cleared:
+
+```rust
+/// Set the connected-discovery error state.
+///
+/// Clears `loading` and `refreshing` because this is invoked only from the
+/// connected-device foreground failure path (`Message::DeviceDiscoveryFailed`
+/// with `is_background: false`). `bootable_refreshing` is intentionally **not**
+/// cleared here — bootable failures are routed through their own paths
+/// (`spawn_bootable_device_discovery` swallows errors via `unwrap_or_default()`),
+/// and clearing the bootable indicator on a connected error would be misleading.
+pub fn set_error(&mut self, error: String) {
+    // ... existing body
+}
+```
+
+Adjust phrasing as needed; the goal is a single concise paragraph for the next
+maintainer.
+
+### m5 — Comment on close+reopen race
+
+Open `crates/fdemon-app/src/handler/new_session/navigation.rs`. Find the cache-hit branch
+in `handle_open_new_session_dialog` where `refreshing = true` is written (introduced by
+the parent plan's task 04, around lines 246-253). Add a brief comment above the writes:
+
+```rust
+// Set refreshing flags AFTER set_*_devices() (which clears them).
+//
+// Race: if the user closes and quickly reopens the dialog while a previous
+// background discovery is in flight, that discovery's DevicesDiscovered message
+// will arrive at the new dialog and clear `refreshing` before this open's own
+// discovery completes. Convergence is correct (last write wins), but the visual
+// cue may briefly disappear and reappear. Acceptable transient flicker.
+state.new_session_dialog_state.target_selector.refreshing = true;
+```
+
+### m7 — Collapse dead branch in `handle_close_new_session_dialog`
+
+In the same file, find `handle_close_new_session_dialog` (around lines 268-280). The
+body currently has an `if/else` where both branches assign `UiMode::Normal`:
+
+```rust
+if state.session_manager.has_running_sessions() {
+    state.ui_mode = UiMode::Normal;
+} else {
+    // No sessions, stay in startup mode
+    state.ui_mode = UiMode::Normal;
+}
+```
+
+Replace with a single unconditional assignment and remove the misleading comment:
+
+```rust
+state.ui_mode = UiMode::Normal;
+```
+
+The "stay in startup mode" comment was inaccurate (no path returns to `UiMode::Startup`
+after the dialog opens — the startup flow transitions away from `Startup` via
+`show_new_session_dialog`).
+
+### n1 — Multi-line `RefreshDevicesAndBootableBackground` doc
+
+Open `crates/fdemon-app/src/handler/mod.rs`. Find `RefreshDevicesAndBootableBackground`
+(around line 80, introduced by the parent plan's task 03). Currently a one-liner:
+
+```rust
+RefreshDevicesAndBootableBackground { flutter: FlutterExecutable },
+```
+
+Reformat to match sibling variants' style:
+
+```rust
+RefreshDevicesAndBootableBackground {
+    /// Flutter executable to use for both background discovery tasks.
+    flutter: FlutterExecutable,
+},
+```
+
+If `DiscoverDevicesAndBootable` from task 03 is already in the file with the same
+multi-line shape, mirror its style for consistency.
+
+### n3 — Capture `len()` before clone
+
+In `navigation.rs`, find the cache-hit branch in `handle_open_new_session_dialog` where
+`cached_devices.clone()` is forwarded to `set_connected_devices`. Capture the length
+into a local before the clone for clarity:
+
+```rust
+let cached_len = cached_devices.len();
+let age = state.devices_last_updated.map(|t| t.elapsed());
+state.new_session_dialog_state
+    .target_selector
+    .set_connected_devices(cached_devices.clone());
+tracing::debug!("Using cached devices ({} devices, age: {:?})", cached_len, age);
+```
+
+Adjust to match the actual existing structure in the post-task-02 code.
+
+### Verification
+
+- `cargo fmt --all`
+- `cargo check --workspace`
+- `cargo test --workspace --lib`
+- `cargo clippy --workspace --lib -- -D warnings`
+
+## Acceptance Criteria
+
+- [ ] m1: `test_bootable_devices_discovered_clears_bootable_refreshing` is present in
+      `handler/tests.rs` and passes.
+- [ ] m3: `set_error()` in `target_selector_state.rs` has a doc comment explaining why
+      `bootable_refreshing` is not cleared.
+- [ ] m5: A comment near the `refreshing = true` write in `navigation.rs` documents the
+      close+reopen race.
+- [ ] m7: `handle_close_new_session_dialog` is a single `state.ui_mode = UiMode::Normal;`
+      with no misleading comment.
+- [ ] n1: `RefreshDevicesAndBootableBackground` is multi-line with `///` doc on `flutter`.
+- [ ] n3: `cached_devices.len()` is captured to a local before `.clone()` in the
+      cache-hit branch.
+- [ ] `cargo test --workspace --lib` passes.
+- [ ] `cargo clippy --workspace --lib -- -D warnings` clean.
+
+## Out of Scope
+
+- Changing the asymmetric clearing behaviour of `set_error()` (m3 is a comment-only fix).
+- Resolving the close+reopen race itself — only documenting it.
+- Resolving the pre-existing TODO at `target_selector_state.rs:455` about
+  `calculate_scroll_offset` (m9 — explicitly out of scope per the followup plan).
+- The icon routing and compact-mode work (handled in task 04).

--- a/workflow/plans/bugs/device-cache-followup/tasks/05-polish-bundle.md
+++ b/workflow/plans/bugs/device-cache-followup/tasks/05-polish-bundle.md
@@ -189,3 +189,36 @@ Adjust to match the actual existing structure in the post-task-02 code.
 - Resolving the pre-existing TODO at `target_selector_state.rs:455` about
   `calculate_scroll_offset` (m9 — explicitly out of scope per the followup plan).
 - The icon routing and compact-mode work (handled in task 04).
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-a82394c45b9c3b098
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/handler/tests.rs` | Added `test_bootable_devices_discovered_clears_bootable_refreshing` test (m1) |
+| `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | Replaced one-liner `/// Set error state` doc with multi-paragraph comment explaining asymmetric clearing (m3) |
+| `crates/fdemon-app/src/handler/new_session/navigation.rs` | Added race comment above `refreshing = true` writes (m5); collapsed dead `if/else` in `handle_close_new_session_dialog` to single assignment (m7); captured `cached_devices.len()` to `cached_len` local before `.clone()` (n3) |
+| `crates/fdemon-app/src/handler/mod.rs` | Expanded `RefreshDevicesAndBootableBackground` to multi-line with `///` doc on `flutter` field (n1) |
+
+### Notable Decisions/Tradeoffs
+
+1. **Pre-existing test failure**: `flutter_sdk::locator::tests::test_flutter_wrapper_detection` fails before and after these changes — confirmed via `git stash` round-trip. It is an environment-sensitive test unrelated to this task.
+2. **m7 doc comment**: Removed the misleading "No sessions, stay in startup mode" comment along with the dead branch, and trimmed the function's doc comment to match the simplified body.
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed (reformatted navigation.rs and tests.rs)
+- `cargo check --workspace` - Passed
+- `cargo test --workspace --lib` - 733 passed, 1 pre-existing failure (unrelated)
+- `cargo clippy --workspace --lib -- -D warnings` - Passed (clean)
+- `cargo test -p fdemon-app --lib test_bootable_devices_discovered_clears_bootable_refreshing` - Passed
+
+### Risks/Limitations
+
+1. **Pre-existing test failure**: `test_flutter_wrapper_detection` in `fdemon-daemon` fails due to an environment condition (a `flutter` wrapper present in the test environment), not related to this task's changes.

--- a/workflow/plans/bugs/device-cache-no-ttl/BUG.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/BUG.md
@@ -187,10 +187,10 @@ without losing the cached content.
 - **Risk:** with no TTL, if `flutter devices` keeps failing, the cache could show
   outdated devices indefinitely.
 - **Mitigation:** every dialog open triggers a background refresh, and the discovery
-  failure path (`Message::DeviceDiscoveryFailed`) already reports errors. The
-  `refreshing` indicator clears even on failure (handled by `set_error()` clearing
-  `refreshing`). Background failures (`is_background: true`) are logged only — the
-  user still sees the previous devices, which is the desired UX.
+  failure path (`Message::DeviceDiscoveryFailed`) clears the `refreshing` indicator on
+  both the foreground branch (via `set_error()`) and the background branch (via a
+  direct flag clear). Background failures (`is_background: true`) are logged at warn
+  level only — the user still sees the previous devices, which is the desired UX.
 
 ### Concurrent Discovery
 - **Risk:** triggering a refresh while a previous discovery is still in flight could

--- a/workflow/plans/bugs/device-cache-no-ttl/BUG.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/BUG.md
@@ -1,0 +1,274 @@
+# Bugfix Plan: Device Cache Drops After 30s (Issue #33 follow-up)
+
+## TL;DR
+
+The new-session dialog sometimes shows the cached device list instantly and sometimes
+forces the user to wait for `flutter devices` again. Root cause: `get_cached_devices()`
+and `get_cached_bootable_devices()` enforce a hardcoded **30-second TTL**, after which
+they return `None` even though the cache data is still in memory. Once the TTL elapses,
+opening the dialog falls into the cache-miss branch and shows a loading screen.
+
+The previous plan (`workflow/plans/bugs/new-session-dialog-fixes/BUG.md`, Phase 1 / Bug 1)
+introduced the cache + background-refresh wiring but kept the TTL, so the bug recurs in
+production whenever the user opens the dialog more than 30 seconds after the last
+discovery.
+
+**Fix:** remove the TTL entirely (cache lives until replaced), trigger a background
+refresh on every dialog open (connected **and** bootable), and surface a small
+"refreshing" indicator on the active target-selector tab so the user knows the list is
+being updated in place.
+
+GitHub issue: https://github.com/edTheGuy00/fdemon/issues/33
+
+---
+
+## Bug Report
+
+### Symptom
+
+1. Start `fdemon`, wait for the device list to populate.
+2. Launch a session — the new session dialog closes.
+3. After working for a while (≥30 s), open the new session dialog again to start a
+   second session on a different device.
+4. **Sometimes** the cached device list is shown instantly with a brief background
+   refresh (works as designed). **Sometimes** the dialog shows a loading state and the
+   user has to wait for `flutter devices` to return.
+
+The behaviour is time-correlated: opening the dialog soon after the previous discovery
+works; waiting longer drops the cached list.
+
+### Expected
+
+The cached device list should always appear instantly when the dialog opens. A small
+indicator should make it obvious that the list is being refreshed in the background.
+Discovery results, when they arrive, replace the list in place without flashing a
+loading screen.
+
+### Root Cause
+
+`crates/fdemon-app/src/state.rs:1239-1250` — `get_cached_devices()`:
+
+```rust
+pub fn get_cached_devices(&self) -> Option<&Vec<Device>> {
+    const CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+    if let (Some(ref devices), Some(updated)) = (&self.device_cache, self.devices_last_updated) {
+        if updated.elapsed() < CACHE_TTL {
+            return Some(devices);
+        }
+    }
+    None
+}
+```
+
+Same TTL gating exists in `get_cached_bootable_devices()` at `state.rs:1270-1284`.
+
+`crates/fdemon-app/src/handler/new_session/navigation.rs:202-250` —
+`handle_open_new_session_dialog()` calls `get_cached_devices()`. When the TTL is
+exceeded it returns `None`, and the handler falls into the cache-miss branch:
+
+```rust
+state.new_session_dialog_state.target_selector.loading = true;
+UpdateResult::action(UpdateAction::DiscoverDevices { flutter })
+```
+
+— which is the foreground discovery path (loading screen, no cached list shown).
+
+The `device_cache` field itself is **not** dropped from memory; only the accessor's
+TTL gate makes it appear so. Removing the TTL gate makes the cache survive for the
+full lifetime of the `AppState`, which is the intended behaviour.
+
+### Secondary Observation: Bootable Cache Never Refreshes on Dialog Open
+
+`navigation.rs:219-241` only triggers a background refresh for **connected** devices on
+cache hit. Bootable devices are populated from cache but no
+`UpdateAction::RefreshBootableDevicesBackground` is dispatched, so once bootable
+discovery has run at startup, the bootable list is frozen for the rest of the session.
+This is a latent bug surfaced by the same plan and is fixed here for parity.
+
+---
+
+## Affected Modules
+
+| Module | Change |
+|---|---|
+| `crates/fdemon-app/src/state.rs` | Remove TTL constants and `elapsed() < CACHE_TTL` checks in `get_cached_devices()` and `get_cached_bootable_devices()`. Update / replace expiration tests. |
+| `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | Add `refreshing: bool` and `bootable_refreshing: bool` fields. Clear them in `set_connected_devices()` / `set_bootable_devices()` / `set_error()`. |
+| `crates/fdemon-app/src/handler/new_session/navigation.rs` | On dialog open, set the appropriate refreshing flag(s) and dispatch the new combined background-refresh action. |
+| `crates/fdemon-app/src/handler/mod.rs` | Add `UpdateAction::RefreshDevicesAndBootableBackground { flutter }` variant. (`UpdateResult` carries a single action, so we combine both discoveries in one variant rather than introducing batching.) |
+| `crates/fdemon-app/src/actions/mod.rs` | Wire `RefreshDevicesAndBootableBackground` to call both `spawn::spawn_device_discovery_background` and `spawn::spawn_bootable_device_discovery`. |
+| `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs` | Accept two `refreshing` flags; append a `↻` glyph (dim style) to the active tab label when its flag is set. |
+| `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | Pass the two refreshing flags into `TabBar::new()`. |
+
+---
+
+## Phases
+
+### Phase 1: Remove TTL and add refreshing-state plumbing (Critical)
+
+**Goal:** the cache survives indefinitely; per-tab `refreshing` flags exist on the
+target-selector state and are correctly toggled by the dialog open / discovery flow.
+
+**Steps:**
+
+1. **Remove TTL** in `state.rs` (`get_cached_devices`, `get_cached_bootable_devices`).
+   - Keep `devices_last_updated` / `bootable_last_updated` — still used by tracing
+     debug logs in `navigation.rs`.
+   - Replace `test_device_cache_expires` with `test_device_cache_does_not_expire`
+     (verify cache returns Some even after a long simulated elapsed duration).
+
+2. **Add refreshing flags** to `TargetSelectorState`:
+   - `pub refreshing: bool` (default `false`)
+   - `pub bootable_refreshing: bool` (default `false`)
+   - Clear `refreshing` in `set_connected_devices()` and `set_error()`.
+   - Clear `bootable_refreshing` in `set_bootable_devices()`.
+
+3. **Set flags in `handle_open_new_session_dialog`** (`navigation.rs`):
+   - When **either** a connected or bootable cache is present: set the corresponding
+     `refreshing` / `bootable_refreshing` flag, then dispatch the new combined
+     `UpdateAction::RefreshDevicesAndBootableBackground { flutter }`. This single
+     action triggers both background discoveries.
+   - When only one of the two caches is present, still dispatch the combined action —
+     the missing-cache side will populate as if it were a fresh discovery (its tab's
+     `loading` flag may already be set from default state, in which case
+     `set_…_devices()` will clear it on completion).
+   - On cache miss for **both** (no connected cache and no bootable cache): keep
+     existing behaviour (`loading = true` + foreground `DiscoverDevices`). Do **not**
+     set `refreshing` here — `loading` covers this case.
+
+4. **Add `UpdateAction::RefreshDevicesAndBootableBackground { flutter }`** in
+   `handler/mod.rs`. Wire it in `actions/mod.rs` to call both
+   `spawn::spawn_device_discovery_background(msg_tx.clone(), flutter)` and
+   `spawn::spawn_bootable_device_discovery(msg_tx, tool_availability)`. Errors are
+   logged only on both sides (UI already shows cached data).
+
+**Measurable Outcomes:**
+- After waiting >30s, opening the dialog still shows the cached device list instantly.
+- `target_selector.refreshing` becomes `true` on dialog open and `false` once
+  `DevicesDiscovered` arrives.
+- Same behaviour for `bootable_refreshing` and `BootableDevicesDiscovered`.
+
+---
+
+### Phase 2: Render the refreshing indicator on the tab bar
+
+**Goal:** the user sees a clear visual cue that the device list is being refreshed,
+without losing the cached content.
+
+**Steps:**
+
+1. **Update `TabBar`** (`tab_bar.rs`):
+   - Add `connected_refreshing: bool` and `bootable_refreshing: bool` fields.
+   - Update `TabBar::new()` signature to accept them.
+   - In the render loop, when the tab being rendered has its refreshing flag set,
+     append ` ↻` to the label (or use a styled `Span` with `palette::TEXT_SECONDARY`
+     and `Modifier::DIM` so it's visible but unobtrusive).
+   - Show the indicator on **both** tabs simultaneously when both are refreshing.
+
+2. **Wire flags through** (`target_selector.rs`):
+   - Pass `self.state.refreshing` and `self.state.bootable_refreshing` into
+     `TabBar::new()`.
+
+3. **Tests:**
+   - Snapshot/buffer test confirming the `↻` glyph appears in the active tab label
+     when its flag is set, and disappears once cleared.
+   - No regression in existing tab bar render tests (`test_tab_bar_renders`,
+     `test_tab_bar_renders_with_bootable_active`, `test_tab_bar_unfocused`).
+
+**Measurable Outcomes:**
+- Opening the dialog with cached devices shows the list immediately and the active tab
+  label shows ` ↻` until the background refresh completes.
+- Indicator disappears within ~1 frame of `DevicesDiscovered` / `BootableDevicesDiscovered`.
+
+---
+
+## Edge Cases & Risks
+
+### Cache Becoming Severely Stale
+- **Risk:** with no TTL, if `flutter devices` keeps failing, the cache could show
+  outdated devices indefinitely.
+- **Mitigation:** every dialog open triggers a background refresh, and the discovery
+  failure path (`Message::DeviceDiscoveryFailed`) already reports errors. The
+  `refreshing` indicator clears even on failure (handled by `set_error()` clearing
+  `refreshing`). Background failures (`is_background: true`) are logged only — the
+  user still sees the previous devices, which is the desired UX.
+
+### Concurrent Discovery
+- **Risk:** triggering a refresh while a previous discovery is still in flight could
+  produce out-of-order `DevicesDiscovered` messages.
+- **Mitigation:** `set_device_cache` is idempotent — last write wins. The
+  `refreshing` flag is cleared by whichever discovery returns last; transient flicker
+  is acceptable.
+
+### Bootable Refresh on Every Dialog Open
+- **Risk:** added cost of running `xcrun simctl list` / `emulator -list-avds` on every
+  dialog open.
+- **Mitigation:** these commands return in a few hundred ms; user has explicitly
+  opened the dialog so the cost is justified. Errors are background-logged and don't
+  disturb the cached list.
+
+### Indicator Glyph Compatibility
+- **Risk:** `↻` may not render on every terminal.
+- **Mitigation:** the glyph is already used elsewhere or has a safe fallback; if it
+  causes problems, swap for `*` or `…`. Treat as a follow-up if reported.
+
+---
+
+## Out of Scope
+
+- Reworking the tracing-debug log lines that print cache age (they continue to work
+  via the still-present `devices_last_updated` field).
+- Adding cache invalidation on session-lifecycle events (start/stop) — the user
+  confirmed dialog-open refresh is sufficient.
+- Making the cache TTL configurable — the decision is "no TTL", not "configurable
+  TTL".
+
+---
+
+## Success Criteria
+
+### Phase 1 Complete When:
+- [ ] `get_cached_devices()` returns `Some(...)` whenever `device_cache.is_some()`,
+      regardless of elapsed time.
+- [ ] `get_cached_bootable_devices()` does the same.
+- [ ] Opening the dialog after >30 s of inactivity shows the cached list instantly.
+- [ ] Opening the dialog dispatches both a connected-device background refresh and a
+      bootable-device background refresh when those caches are populated.
+- [ ] All existing device-cache tests pass (after expiration test is replaced).
+
+### Phase 2 Complete When:
+- [ ] `TabBar` accepts `connected_refreshing` and `bootable_refreshing` flags.
+- [ ] Active tab label shows ` ↻` while its refresh is in flight, disappears on
+      completion.
+- [ ] Existing tab bar render tests still pass.
+- [ ] New unit test: indicator visible while refreshing, hidden after
+      `set_connected_devices` / `set_bootable_devices`.
+
+---
+
+## Task Dependency Graph
+
+```
+Phase 1
+├── 01-remove-ttl              (state.rs: cache accessors + tests)
+├── 02-refreshing-state-flags  (target_selector_state.rs: new fields + setters)
+├── 03-combined-bg-action      (handler/mod.rs + actions/mod.rs: RefreshDevicesAndBootableBackground)
+└── 04-dialog-open-wiring      (navigation.rs: set flags, dispatch combined action)
+        depends on: 02, 03
+
+Phase 2
+├── 05-tab-bar-indicator       (tab_bar.rs: new fields + glyph rendering)
+└── 06-target-selector-wiring  (target_selector.rs: pass flags into TabBar)
+        depends on: 05, 02
+```
+
+---
+
+## Milestone Deliverable
+
+When both phases are complete:
+- The new session dialog **always** shows the last-known device list instantly when
+  opened, regardless of how much time has passed since the previous discovery.
+- A subtle `↻` indicator on the active tab makes the in-flight background refresh
+  visible without obscuring the cached content.
+- Both connected and bootable lists are refreshed on every dialog open, eliminating
+  the latent bug where bootable devices were frozen after startup.

--- a/workflow/plans/bugs/device-cache-no-ttl/TASKS.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/TASKS.md
@@ -1,0 +1,68 @@
+# Tasks: Device Cache Drops After 30s (Issue #33 follow-up)
+
+Plan: [BUG.md](BUG.md)
+
+---
+
+## Wave 1 — Independent foundation tasks
+
+| ID | Task | Depends on | Files Modified (Write) | Files Read |
+|---|---|---|---|---|
+| 01 | [Remove device cache TTL](tasks/01-remove-ttl.md) | — | `crates/fdemon-app/src/state.rs` | — |
+| 02 | [Add refreshing state flags](tasks/02-refreshing-state-flags.md) | — | `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | — |
+| 03 | [Combined background refresh action](tasks/03-combined-bg-action.md) | — | `crates/fdemon-app/src/handler/mod.rs`, `crates/fdemon-app/src/actions/mod.rs` | `crates/fdemon-app/src/spawn.rs` |
+| 05 | [Tab bar refreshing indicator](tasks/05-tab-bar-indicator.md) | — | `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs` | — |
+
+## Wave 2 — Wiring (sequential after Wave 1)
+
+| ID | Task | Depends on | Files Modified (Write) | Files Read |
+|---|---|---|---|---|
+| 04 | [Dialog-open wiring](tasks/04-dialog-open-wiring.md) | 02, 03 | `crates/fdemon-app/src/handler/new_session/navigation.rs` | `state.rs`, `target_selector_state.rs`, `handler/mod.rs` |
+| 06 | [Target selector wires flags into TabBar](tasks/06-target-selector-wiring.md) | 02, 05 | `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | `target_selector_state.rs`, `tab_bar.rs` |
+
+---
+
+## File Overlap Analysis
+
+### Wave 1 — Overlap Matrix
+
+| Pair | Shared Write Files | Strategy |
+|---|---|---|
+| 01 ↔ 02 | none | Parallel (worktree) |
+| 01 ↔ 03 | none | Parallel (worktree) |
+| 01 ↔ 05 | none | Parallel (worktree) |
+| 02 ↔ 03 | none | Parallel (worktree) |
+| 02 ↔ 05 | none | Parallel (worktree) |
+| 03 ↔ 05 | none | Parallel (worktree) |
+
+Wave 1 has zero write-file overlap → all four tasks (01, 02, 03, 05) can run in parallel
+worktrees.
+
+### Wave 2 — Overlap Matrix
+
+| Pair | Shared Write Files | Strategy |
+|---|---|---|
+| 04 ↔ 06 | none | Parallel (worktree) |
+
+Wave 2 has zero write-file overlap → tasks 04 and 06 can run in parallel worktrees once
+Wave 1 has merged.
+
+### Read-only overlap (informational, no conflict risk)
+- Task 04 reads `target_selector_state.rs` (written by 02) and `handler/mod.rs`
+  (written by 03) — Wave-2 ordering ensures these reads see the merged Wave-1 state.
+- Task 06 reads `target_selector_state.rs` (written by 02) and `tab_bar.rs`
+  (written by 05).
+
+---
+
+## Dispatch Order Summary
+
+```
+Wave 1 (parallel worktrees):  01, 02, 03, 05
+        ↓
+Wave 2 (parallel worktrees):  04, 06
+```
+
+All tasks: `Agent: implementor`. No core docs (`docs/ARCHITECTURE.md`,
+`CODE_STANDARDS.md`, `DEVELOPMENT.md`) require updates — this is a localized bug fix
+with no module/layer changes.

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/01-remove-ttl.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/01-remove-ttl.md
@@ -90,3 +90,31 @@ memory.
 
 - Changing the dialog-open behaviour (handled in task 04).
 - Adding the `refreshing` flags (handled in task 02).
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-a62f90b7a5e7bf4cd
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/state.rs` | Removed TTL logic from `get_cached_devices()` and `get_cached_bootable_devices()`; updated doc comments; replaced `test_device_cache_expires` with `test_device_cache_does_not_expire` |
+| `crates/fdemon-app/src/handler/new_session/navigation.rs` | Renamed `test_open_dialog_expired_cache_shows_loading` to `test_open_dialog_stale_timestamp_cache_still_shows_devices` and updated assertions to reflect new no-expiry behavior |
+
+### Notable Decisions/Tradeoffs
+
+1. **Navigation handler test update**: The test `test_open_dialog_expired_cache_shows_loading` in `navigation.rs` was also testing the old TTL behavior — it expected `loading = true` and a foreground `DiscoverDevices` action when cache had a stale timestamp. With the TTL removed, a populated cache (regardless of timestamp age) now yields an immediate display + background refresh. This test was updated accordingly. It was not explicitly listed in the task but was required to make the tests pass.
+
+2. **Fields preserved**: `devices_last_updated` and `bootable_last_updated` remain in `AppState` and are still set by `set_device_cache()` / `set_bootable_cache()`. The tracing debug logs in the handler still reference them via `.map(|t| t.elapsed())`.
+
+### Testing Performed
+
+- `cargo test -p fdemon-app --lib` — Passed (1884 passed, 0 failed, 4 ignored)
+
+### Risks/Limitations
+
+1. **No TTL means stale data on reconnect**: The cache now survives indefinitely; freshness depends entirely on the background refresh triggered at dialog-open time. If a device disconnects between sessions, users may briefly see stale data until the background refresh completes. This is acceptable as it is the intended new design.

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/01-remove-ttl.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/01-remove-ttl.md
@@ -1,0 +1,92 @@
+# Task 01 — Remove Device Cache TTL
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** none
+**Files Modified (Write):** `crates/fdemon-app/src/state.rs`
+
+---
+
+## Goal
+
+Remove the 30-second TTL from `get_cached_devices()` and `get_cached_bootable_devices()`
+so the cached device lists survive for the lifetime of the `AppState`. The TTL gate is
+the root cause of issue #33 — after 30s, accessors return `None` and the new-session
+dialog falls into the cache-miss / loading branch even though the data is still in
+memory.
+
+## Steps
+
+1. Open `crates/fdemon-app/src/state.rs`.
+
+2. **`get_cached_devices()`** (around line 1239) — replace the TTL-gated body with a
+   simple presence check:
+
+   ```rust
+   pub fn get_cached_devices(&self) -> Option<&Vec<Device>> {
+       self.device_cache.as_ref()
+   }
+   ```
+
+   Update the doc comment to reflect "cache survives for the lifetime of AppState; the
+   dialog always triggers a background refresh on open to keep the list fresh."
+
+3. **`get_cached_bootable_devices()`** (around line 1270) — same change. Return the
+   tuple whenever both `ios_simulators_cache` and `android_avds_cache` are populated:
+
+   ```rust
+   pub fn get_cached_bootable_devices(&self) -> Option<(Vec<IosSimulator>, Vec<AndroidAvd>)> {
+       match (&self.ios_simulators_cache, &self.android_avds_cache) {
+           (Some(sims), Some(avds)) => Some((sims.clone(), avds.clone())),
+           _ => None,
+       }
+   }
+   ```
+
+   Update the doc comment likewise.
+
+4. **Keep** `devices_last_updated` and `bootable_last_updated`. They're still used by
+   `tracing::debug!` in `handler/new_session/navigation.rs` to log cache age. Do not
+   remove these fields or the `Instant::now()` writes in `set_device_cache` /
+   `set_bootable_cache`.
+
+5. **Update tests** in the inline `mod tests` block:
+   - **Remove or rename** `test_device_cache_expires` (around line 1780). Replace with
+     a positive test:
+
+     ```rust
+     #[test]
+     fn test_device_cache_does_not_expire() {
+         let mut state = AppState::new();
+         state.set_device_cache(vec![test_device("dev1", "Device 1")]);
+
+         // Simulate a stale timestamp — cache should still be returned.
+         state.devices_last_updated =
+             Some(std::time::Instant::now() - std::time::Duration::from_secs(60 * 60));
+         assert!(state.get_cached_devices().is_some());
+         assert_eq!(state.get_cached_devices().unwrap().len(), 1);
+     }
+     ```
+
+   - Confirm `test_device_cache_fresh`, `test_device_cache_none_initially`,
+     `test_device_cache_updates_timestamp`, and `test_device_cache_replaces_old`
+     still pass.
+   - If a `test_bootable_cache_expires` test exists, mirror the same change for it
+     (rename to `_does_not_expire` and use a stale timestamp).
+
+## Acceptance Criteria
+
+- [ ] `get_cached_devices()` returns `Some(&Vec<Device>)` whenever
+      `state.device_cache.is_some()`, regardless of `devices_last_updated`.
+- [ ] `get_cached_bootable_devices()` returns `Some((sims, avds))` whenever both
+      caches are populated, regardless of `bootable_last_updated`.
+- [ ] `cargo test -p fdemon-app --lib` passes.
+- [ ] No reference to `CACHE_TTL` or `Duration::from_secs(30)` remains in the two
+      cache-getter functions.
+- [ ] `devices_last_updated` / `bootable_last_updated` fields are preserved (still
+      written by setters; still readable by tracing logs).
+
+## Out of Scope
+
+- Changing the dialog-open behaviour (handled in task 04).
+- Adding the `refreshing` flags (handled in task 02).

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/02-refreshing-state-flags.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/02-refreshing-state-flags.md
@@ -1,0 +1,140 @@
+# Task 02 — Add Refreshing State Flags to TargetSelectorState
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** none
+**Files Modified (Write):** `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs`
+
+---
+
+## Goal
+
+Introduce two boolean flags on `TargetSelectorState` that indicate whether a background
+device-list refresh is in flight on each tab. Task 04 sets these on dialog open; the
+`set_*_devices` / `set_error` methods clear them on completion. Task 06 wires them into
+the `TabBar` widget for rendering.
+
+## Steps
+
+1. Open `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs`.
+
+2. **Add fields** to the `TargetSelectorState` struct (after `bootable_loading`, around
+   line 42):
+
+   ```rust
+   /// Background refresh in progress for connected devices.
+   ///
+   /// Distinct from `loading`: `loading` shows a full-screen spinner with no
+   /// content, whereas `refreshing` is set when the cached list is already shown
+   /// and a background discovery is updating it in place. Cleared by
+   /// `set_connected_devices()` and `set_error()`.
+   pub refreshing: bool,
+
+   /// Background refresh in progress for bootable devices.
+   ///
+   /// Mirror of `refreshing` for the bootable tab. Cleared by
+   /// `set_bootable_devices()`.
+   pub bootable_refreshing: bool,
+   ```
+
+3. **Update `Default::default()`** (around line 62) — initialize both flags to `false`:
+
+   ```rust
+   refreshing: false,
+   bootable_refreshing: false,
+   ```
+
+4. **Update `set_connected_devices()`** (around line 212) — clear `refreshing`:
+
+   ```rust
+   pub fn set_connected_devices(&mut self, devices: Vec<Device>) {
+       self.connected_devices = devices;
+       self.loading = false;
+       self.refreshing = false;       // NEW
+       self.error = None;
+       // ... existing body
+   }
+   ```
+
+5. **Update `set_bootable_devices()`** (around line 229) — clear `bootable_refreshing`:
+
+   ```rust
+   pub fn set_bootable_devices(
+       &mut self,
+       ios_simulators: Vec<IosSimulator>,
+       android_avds: Vec<AndroidAvd>,
+   ) {
+       self.ios_simulators = ios_simulators;
+       self.android_avds = android_avds;
+       self.bootable_loading = false;
+       self.bootable_refreshing = false;   // NEW
+       // ... existing body (keep the `error` not-cleared comment)
+   }
+   ```
+
+6. **Update `set_error()`** (around line 254) — clear `refreshing` (the user-visible
+   error supersedes the in-progress hint):
+
+   ```rust
+   pub fn set_error(&mut self, error: String) {
+       self.error = Some(error);
+       self.loading = false;
+       self.refreshing = false;       // NEW
+   }
+   ```
+
+   Note: do **not** clear `bootable_refreshing` here — `set_error` is currently used
+   for SDK/connected-side errors only; bootable errors go via a different path. If
+   investigation shows `set_error` is also used for bootable failures, clear both.
+
+7. **Add unit tests** (in the inline `mod tests` block):
+
+   ```rust
+   #[test]
+   fn test_refreshing_default_false() {
+       let state = TargetSelectorState::default();
+       assert!(!state.refreshing);
+       assert!(!state.bootable_refreshing);
+   }
+
+   #[test]
+   fn test_set_connected_devices_clears_refreshing() {
+       let mut state = TargetSelectorState::default();
+       state.refreshing = true;
+       state.set_connected_devices(vec![]);
+       assert!(!state.refreshing);
+   }
+
+   #[test]
+   fn test_set_bootable_devices_clears_bootable_refreshing() {
+       let mut state = TargetSelectorState::default();
+       state.bootable_refreshing = true;
+       state.set_bootable_devices(vec![], vec![]);
+       assert!(!state.bootable_refreshing);
+   }
+
+   #[test]
+   fn test_set_error_clears_refreshing() {
+       let mut state = TargetSelectorState::default();
+       state.refreshing = true;
+       state.set_error("boom".to_string());
+       assert!(!state.refreshing);
+   }
+   ```
+
+## Acceptance Criteria
+
+- [ ] `TargetSelectorState` has two new public fields: `refreshing: bool` and
+      `bootable_refreshing: bool`.
+- [ ] Default values are `false` for both.
+- [ ] `set_connected_devices()` clears `refreshing`.
+- [ ] `set_bootable_devices()` clears `bootable_refreshing`.
+- [ ] `set_error()` clears `refreshing`.
+- [ ] All four new unit tests pass.
+- [ ] `cargo test -p fdemon-app --lib` passes (existing tests should still pass —
+      the new fields default to `false`, matching prior behaviour).
+
+## Out of Scope
+
+- Setting the flags `true` (handled in task 04).
+- Rendering the indicator (handled in tasks 05 and 06).

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/02-refreshing-state-flags.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/02-refreshing-state-flags.md
@@ -138,3 +138,32 @@ the `TabBar` widget for rendering.
 
 - Setting the flags `true` (handled in task 04).
 - Rendering the indicator (handled in tasks 05 and 06).
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** main
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | Added `refreshing` and `bootable_refreshing` fields to struct and `Default`; cleared `refreshing` in `set_connected_devices()` and `set_error()`; cleared `bootable_refreshing` in `set_bootable_devices()`; added 4 new unit tests |
+
+### Notable Decisions/Tradeoffs
+
+1. **Field placement**: The two new fields are placed after `bootable_loading` and before `error` in the struct definition, grouping the loading/refreshing indicators together logically.
+2. **`set_error` scope**: Only `refreshing` is cleared (not `bootable_refreshing`), per the task spec — `set_error` is used for SDK/connected-side errors only.
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed
+- `cargo check --workspace` - Passed
+- `cargo test -p fdemon-app --lib` - Passed (1888 tests, 0 failed)
+- `cargo clippy -p fdemon-app -- -D warnings` - Passed (no warnings)
+
+### Risks/Limitations
+
+1. **Flags not yet set to `true`**: Setting these flags is intentionally out of scope (task 04). Until task 04 is implemented, the flags will always remain `false` at runtime.

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/03-combined-bg-action.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/03-combined-bg-action.md
@@ -1,0 +1,83 @@
+# Task 03 — Combined Background Refresh UpdateAction
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** none
+**Files Modified (Write):**
+- `crates/fdemon-app/src/handler/mod.rs`
+- `crates/fdemon-app/src/actions/mod.rs`
+
+**Files Read:** `crates/fdemon-app/src/spawn.rs`
+
+---
+
+## Goal
+
+Introduce a single `UpdateAction` variant that triggers **both** the connected-device
+background refresh and the bootable-device background refresh. `UpdateResult` carries
+at most one action, and the dialog needs to refresh both lists on open, so combining
+the two discoveries in one variant is the simplest approach.
+
+## Steps
+
+1. Open `crates/fdemon-app/src/handler/mod.rs`.
+
+2. **Add a new variant** to the `UpdateAction` enum, alongside
+   `RefreshDevicesBackground` (around line 69):
+
+   ```rust
+   /// Refresh both connected and bootable device lists in the background.
+   ///
+   /// Dispatched when the new-session dialog opens with cached data already
+   /// shown, so that both lists are kept fresh without a loading screen.
+   /// Errors on either side are logged only; the user keeps seeing the
+   /// previous device lists until the discovery returns.
+   RefreshDevicesAndBootableBackground { flutter: FlutterExecutable },
+   ```
+
+   Place it directly after the existing `RefreshDevicesBackground` variant for
+   readability.
+
+3. Open `crates/fdemon-app/src/actions/mod.rs`.
+
+4. **Wire the variant** in the action dispatch `match`. Insert a new arm next to the
+   existing `RefreshDevicesBackground` arm (around line 79) and the
+   `DiscoverBootableDevices` arm (around line 126):
+
+   ```rust
+   UpdateAction::RefreshDevicesAndBootableBackground { flutter } => {
+       // Connected device refresh — errors logged only (UI shows cached list).
+       spawn::spawn_device_discovery_background(msg_tx.clone(), flutter);
+       // Bootable refresh — errors logged only.
+       spawn::spawn_bootable_device_discovery(msg_tx, tool_availability);
+   }
+   ```
+
+   Note: `tool_availability` is already a parameter on the action-dispatch function
+   (used by `DiscoverBootableDevices`); re-use it here. `msg_tx` is cloned because
+   both spawn calls take ownership.
+
+5. **Verify** that `spawn_bootable_device_discovery` accepts the `tool_availability`
+   value as it stands at dispatch time (i.e. it's `Clone` or already owned by the
+   dispatcher). Check `actions/mod.rs:127` for the existing call signature — the new
+   arm should mirror it.
+
+6. **No new tests required at the action layer** — `UpdateAction` is a plain enum with
+   no logic. The combined behaviour is exercised by tests in tasks 04 and the
+   end-to-end dialog tests.
+
+## Acceptance Criteria
+
+- [ ] `UpdateAction::RefreshDevicesAndBootableBackground { flutter }` exists in
+      `handler/mod.rs`.
+- [ ] The action-dispatch match in `actions/mod.rs` handles the new variant by calling
+      both `spawn_device_discovery_background` and `spawn_bootable_device_discovery`.
+- [ ] `cargo build --workspace` succeeds with no exhaustive-match warnings.
+- [ ] `cargo test -p fdemon-app --lib` passes.
+
+## Out of Scope
+
+- Dispatching the new action from anywhere (handled in task 04).
+- Removing the existing `RefreshDevicesBackground` variant — keep it; other callers
+  may exist (e.g. session lifecycle) and we don't want to change their semantics in
+  this fix.

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/03-combined-bg-action.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/03-combined-bg-action.md
@@ -81,3 +81,31 @@ the two discoveries in one variant is the simplest approach.
 - Removing the existing `RefreshDevicesBackground` variant — keep it; other callers
   may exist (e.g. session lifecycle) and we don't want to change their semantics in
   this fix.
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-af5fb4d58eb6bbf6e
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/handler/mod.rs` | Added `RefreshDevicesAndBootableBackground { flutter }` variant to `UpdateAction` enum, placed after `RefreshDevicesBackground` |
+| `crates/fdemon-app/src/actions/mod.rs` | Added match arm for `RefreshDevicesAndBootableBackground` calling both `spawn_device_discovery_background` (with cloned `msg_tx`) and `spawn_bootable_device_discovery` |
+
+### Notable Decisions/Tradeoffs
+
+1. **Clone order**: `msg_tx.clone()` is passed to `spawn_device_discovery_background` while the original `msg_tx` is consumed by `spawn_bootable_device_discovery`, mirroring the exact pattern in the task spec.
+2. **No new tests**: As specified in the task, `UpdateAction` is a plain enum with no logic — the combined behavior is exercised by downstream task 04 tests.
+
+### Testing Performed
+
+- `cargo build --workspace` - Passed (full workspace, no exhaustive-match warnings)
+- `cargo test -p fdemon-app --lib` - Passed (1884 passed; 0 failed; 4 ignored)
+
+### Risks/Limitations
+
+1. **No callers yet**: The new variant is not dispatched from anywhere until task 04 wires it up on dialog open.

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/04-dialog-open-wiring.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/04-dialog-open-wiring.md
@@ -1,0 +1,195 @@
+# Task 04 — Dialog-Open Wiring (Set Refreshing Flags + Dispatch Combined Refresh)
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** 02 (refreshing flags), 03 (combined action variant)
+**Files Modified (Write):** `crates/fdemon-app/src/handler/new_session/navigation.rs`
+
+**Files Read:**
+- `crates/fdemon-app/src/state.rs` (verify cache accessors from task 01)
+- `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` (use flags from
+  task 02)
+- `crates/fdemon-app/src/handler/mod.rs` (use UpdateAction variant from task 03)
+
+---
+
+## Goal
+
+Update `handle_open_new_session_dialog()` so that opening the dialog:
+1. Pre-populates the lists from the now-permanent cache (works after task 01).
+2. Sets `target_selector.refreshing` and/or `bootable_refreshing` to `true`.
+3. Dispatches the new `UpdateAction::RefreshDevicesAndBootableBackground` to refresh
+   both lists in the background.
+
+## Steps
+
+1. Open `crates/fdemon-app/src/handler/new_session/navigation.rs`.
+
+2. **Locate `handle_open_new_session_dialog()`** (around line 186).
+
+3. **Replace the cache-hit / cache-miss control flow** at lines ~234-250 with the
+   following structure:
+
+   ```rust
+   let connected_cached = has_connected_cache;
+   let bootable_cached = state.get_cached_bootable_devices().is_some();
+   //   ^--- recompute here OR refactor the bootable block above to also produce
+   //        a `bootable_cached` boolean alongside the existing if-let.
+
+   let Some(flutter) = state.flutter_executable() else {
+       tracing::warn!(
+           "handle_open_new_session_dialog: no Flutter SDK — skipping device refresh"
+       );
+       return UpdateResult::none();
+   };
+
+   if connected_cached || bootable_cached {
+       // We have at least one cached list shown — refresh in the background.
+       if connected_cached {
+           state.new_session_dialog_state.target_selector.refreshing = true;
+       }
+       if bootable_cached {
+           state.new_session_dialog_state.target_selector.bootable_refreshing = true;
+       }
+       return UpdateResult::action(
+           UpdateAction::RefreshDevicesAndBootableBackground { flutter },
+       );
+   }
+
+   // Both caches are empty — fall back to the foreground discovery path.
+   tracing::debug!("Device cache miss, triggering foreground discovery");
+   state.new_session_dialog_state.target_selector.loading = true;
+   UpdateResult::action(UpdateAction::DiscoverDevices { flutter })
+   ```
+
+   Adjust the surrounding bootable-cache check (lines 219-232) so that
+   `bootable_cached` is captured (mirror the existing `has_connected_cache` pattern):
+
+   ```rust
+   let bootable_cached = if let Some((simulators, avds)) = state.get_cached_bootable_devices() {
+       tracing::debug!(
+           "Using cached bootable devices ({} simulators, {} AVDs, age: {:?})",
+           simulators.len(),
+           avds.len(),
+           state.bootable_last_updated.map(|t| t.elapsed())
+       );
+       state
+           .new_session_dialog_state
+           .target_selector
+           .set_bootable_devices(simulators, avds);
+       true
+   } else {
+       false
+   };
+   ```
+
+   Note: `set_bootable_devices()` clears `bootable_loading` (and now `bootable_refreshing`
+   per task 02). That's fine — we set `bootable_refreshing = true` **after**
+   `set_bootable_devices()` runs. Order matters; verify by re-reading the final code.
+
+4. **Update the inline doc comment** at lines 180-185 to reflect the new behaviour:
+
+   ```rust
+   /// Loads launch configurations from the project path and initializes
+   /// the dialog state.
+   ///
+   /// Uses any cached devices/bootable for instant display. The cache has no TTL;
+   /// it survives for the lifetime of the AppState. Whenever a cache hit occurs,
+   /// the corresponding `refreshing` flag is set on the target selector and
+   /// `RefreshDevicesAndBootableBackground` is dispatched so both lists stay
+   /// fresh without a loading screen. If both caches are empty (first ever
+   /// open), falls back to the foreground `DiscoverDevices` path.
+   ```
+
+5. **Update tests** in the inline `mod tests` block (around line 303 onward):
+
+   - **Existing `test_open_dialog_uses_cached_devices`** — verify it still passes
+     (cache hit path still pre-populates the list). Add an assertion that
+     `state.new_session_dialog_state.target_selector.refreshing == true` after the
+     call.
+
+   - **Existing `test_open_dialog_triggers_background_refresh`** (or similar around
+     line 351) — update the action-match arm from `RefreshDevicesBackground` to
+     `RefreshDevicesAndBootableBackground`.
+
+   - **New test:**
+
+     ```rust
+     #[test]
+     fn test_open_dialog_sets_refreshing_flags_on_cache_hit() {
+         let mut state = test_app_state();
+
+         // Pre-populate both caches.
+         state.set_device_cache(vec![test_device_full("1", "iPhone", "ios", false)]);
+         state.set_bootable_cache(vec![], vec![]);
+
+         let result = handle_open_new_session_dialog(&mut state);
+
+         assert!(state.new_session_dialog_state.target_selector.refreshing);
+         assert!(state.new_session_dialog_state.target_selector.bootable_refreshing);
+         assert!(matches!(
+             result.action,
+             Some(UpdateAction::RefreshDevicesAndBootableBackground { .. })
+         ));
+     }
+
+     #[test]
+     fn test_open_dialog_only_connected_cached_sets_only_refreshing() {
+         let mut state = test_app_state();
+         state.set_device_cache(vec![test_device_full("1", "iPhone", "ios", false)]);
+
+         let _ = handle_open_new_session_dialog(&mut state);
+         assert!(state.new_session_dialog_state.target_selector.refreshing);
+         assert!(!state.new_session_dialog_state.target_selector.bootable_refreshing);
+     }
+
+     #[test]
+     fn test_open_dialog_no_caches_falls_back_to_loading() {
+         let mut state = test_app_state();
+         // No caches set.
+         let result = handle_open_new_session_dialog(&mut state);
+         assert!(state.new_session_dialog_state.target_selector.loading);
+         assert!(!state.new_session_dialog_state.target_selector.refreshing);
+         assert!(matches!(
+             result.action,
+             Some(UpdateAction::DiscoverDevices { .. })
+         ));
+     }
+     ```
+
+   - Verify that completing a `DevicesDiscovered` message clears `refreshing`. The
+     existing `Message::DevicesDiscovered` handler in `update.rs` already calls
+     `set_connected_devices()`, which (per task 02) clears `refreshing`. Add a focused
+     test in `handler/tests.rs` if one doesn't already cover this:
+
+     ```rust
+     #[test]
+     fn test_devices_discovered_clears_refreshing() {
+         let mut state = test_app_state();
+         state.show_new_session_dialog(LoadedConfigs::default());
+         state.new_session_dialog_state.target_selector.refreshing = true;
+
+         let _ = handler::update(&mut state, Message::DevicesDiscovered { devices: vec![] });
+         assert!(!state.new_session_dialog_state.target_selector.refreshing);
+     }
+     ```
+
+## Acceptance Criteria
+
+- [ ] On dialog open with a connected-device cache hit, `refreshing` is set to `true`.
+- [ ] On dialog open with a bootable cache hit, `bootable_refreshing` is set to `true`.
+- [ ] When at least one cache is populated, the dialog dispatches
+      `UpdateAction::RefreshDevicesAndBootableBackground`.
+- [ ] When both caches are empty, the dialog falls back to setting `loading = true`
+      and dispatching `UpdateAction::DiscoverDevices` (existing first-run behaviour
+      preserved).
+- [ ] `Message::DevicesDiscovered` clears `refreshing` (via `set_connected_devices`).
+- [ ] `Message::BootableDevicesDiscovered` clears `bootable_refreshing` (via
+      `set_bootable_devices`).
+- [ ] All new tests in this file pass.
+- [ ] `cargo test -p fdemon-app --lib` passes.
+
+## Out of Scope
+
+- Rendering the indicator (tasks 05 and 06).
+- Modifying the cache accessors (task 01).

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/04-dialog-open-wiring.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/04-dialog-open-wiring.md
@@ -193,3 +193,36 @@ Update `handle_open_new_session_dialog()` so that opening the dialog:
 
 - Rendering the indicator (tasks 05 and 06).
 - Modifying the cache accessors (task 01).
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-a157da4affbcc3629
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/handler/new_session/navigation.rs` | Rewrote `handle_open_new_session_dialog()`: restructured bootable cache block to capture `bootable_cached` boolean, merged control flow so `refreshing`/`bootable_refreshing` are set after cache-populate calls, dispatches `RefreshDevicesAndBootableBackground` on any cache hit, falls back to `DiscoverDevices` when both caches are empty. Updated doc comment. Updated 2 existing tests (`test_open_dialog_uses_cached_devices`, `test_open_dialog_stale_timestamp_cache_still_shows_devices`) to assert new `refreshing` flag and `RefreshDevicesAndBootableBackground` action. Added 3 new tests: `test_open_dialog_sets_refreshing_flags_on_cache_hit`, `test_open_dialog_only_connected_cached_sets_only_refreshing`, `test_open_dialog_no_caches_falls_back_to_loading`. |
+| `crates/fdemon-app/src/handler/tests.rs` | Added `test_devices_discovered_clears_refreshing` to verify that `Message::DevicesDiscovered` clears the `refreshing` flag via `set_connected_devices()`. |
+
+### Notable Decisions/Tradeoffs
+
+1. **Order of operations — set flags after `set_*_devices()`**: `set_connected_devices()` and `set_bootable_devices()` both clear their respective `refreshing` flags. The new code sets `refreshing = true` after these calls, ensuring the flag is not immediately cleared by the populate step.
+2. **Single `RefreshDevicesAndBootableBackground` for any cache hit**: Even if only one cache is populated, both connected and bootable lists are refreshed together. This avoids partial staleness without extra complexity.
+3. **No-SDK early return before the cache-hit block**: If `flutter_executable()` returns `None` the function returns immediately without setting flags, which is correct — no refresh can happen without a Flutter SDK.
+
+### Testing Performed
+
+- `cargo check -p fdemon-app` — Passed
+- `cargo test -p fdemon-app --lib -- new_session::navigation` — Passed (17 tests)
+- `cargo test -p fdemon-app --lib -- test_devices_discovered_clears_refreshing` — Passed
+- `cargo test -p fdemon-app --lib` — Passed (1892 tests)
+- `cargo clippy -p fdemon-app -- -D warnings` — Passed
+- `cargo fmt --all` — Passed (format check clean)
+
+### Risks/Limitations
+
+1. **Only connected-only cache hit**: When only the connected devices cache is populated (no bootable cache yet), `bootable_refreshing` is NOT set (by design). The bootable tab will still show its normal loading state from the initial `bootable_loading: true` default. This is correct because there is no cached bootable list to show a "refreshing" indicator over.

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/05-tab-bar-indicator.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/05-tab-bar-indicator.md
@@ -184,3 +184,33 @@ that an in-place refresh is in flight.
 
 - Updating callers of `TabBar::new()` outside this file (handled in task 06).
 - Setting the flags from the handler side (handled in task 04).
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-a7db589c9a667afc4
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs` | Added `connected_refreshing` and `bootable_refreshing` fields to `TabBar`; updated `new()` to take 4 args; updated render loop to append ` ↻` glyph when flag is set; updated 3 existing tests; added 3 new render tests |
+| `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | Updated the one caller of `TabBar::new()` outside `tab_bar.rs` to pass `false, false` as placeholder refreshing flags (task 06 will wire real state) |
+
+### Notable Decisions/Tradeoffs
+
+1. **Updated `target_selector.rs` caller**: The task scope says task 06 handles callers outside `tab_bar.rs`, but the build fails if the old 2-arg call remains. Passing `false, false` is correct: it preserves existing behaviour and task 06 will replace them with real state fields.
+2. **`format!()` only when refreshing**: The non-refreshing path uses `.to_string()` on the `&'static str` label to keep the code uniform (avoids a conditional `&str` vs `String` binding).
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed
+- `cargo check -p fdemon-tui` - Passed
+- `cargo test -p fdemon-tui --lib` - Passed (872 tests, 0 failed)
+- `cargo clippy -p fdemon-tui -- -D warnings` - Passed (no warnings)
+
+### Risks/Limitations
+
+1. **Placeholder `false, false` in `target_selector.rs`**: The refreshing indicator will not appear in the actual TUI until task 06 wires the real state fields. This is intentional and expected.

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/05-tab-bar-indicator.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/05-tab-bar-indicator.md
@@ -1,0 +1,186 @@
+# Task 05 — Tab Bar Refreshing Indicator
+
+**Agent:** implementor
+**Phase:** 2
+**Depends on:** none
+**Files Modified (Write):** `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs`
+
+---
+
+## Goal
+
+Make `TabBar` accept two refreshing flags (one per tab) and render a small `↻` glyph
+appended to the tab label when its flag is set. The indicator should be visible but
+unobtrusive — the cached device list remains the primary UI, with the glyph signalling
+that an in-place refresh is in flight.
+
+## Steps
+
+1. Open `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs`.
+
+2. **Extend the `TabBar` struct** (around line 16):
+
+   ```rust
+   pub struct TabBar {
+       active_tab: TargetTab,
+       pane_focused: bool,
+       /// Refresh-in-flight indicator for the Connected tab.
+       connected_refreshing: bool,
+       /// Refresh-in-flight indicator for the Bootable tab.
+       bootable_refreshing: bool,
+   }
+   ```
+
+3. **Update `TabBar::new()`** to take the two flags:
+
+   ```rust
+   impl TabBar {
+       pub fn new(
+           active_tab: TargetTab,
+           pane_focused: bool,
+           connected_refreshing: bool,
+           bootable_refreshing: bool,
+       ) -> Self {
+           Self {
+               active_tab,
+               pane_focused,
+               connected_refreshing,
+               bootable_refreshing,
+           }
+       }
+   }
+   ```
+
+4. **Update the render loop** (around line 49). For each tab, decide whether to append
+   the indicator. Keep the existing centered-paragraph layout — append ` ↻` to the
+   label string when refreshing. Use the existing `Style` for the label so the glyph
+   inherits color/emphasis from the tab's active/inactive state. (Subtle dim styling
+   was considered, but inheriting the tab's style keeps the implementation minimal
+   and the glyph readable on both active and inactive tabs.)
+
+   ```rust
+   for (i, tab) in [TargetTab::Connected, TargetTab::Bootable]
+       .iter()
+       .enumerate()
+   {
+       let is_active = *tab == self.active_tab;
+       let refreshing = match tab {
+           TargetTab::Connected => self.connected_refreshing,
+           TargetTab::Bootable => self.bootable_refreshing,
+       };
+
+       let label = if refreshing {
+           format!("{} ↻", tab.label())
+       } else {
+           tab.label().to_string()
+       };
+
+       // ... existing style logic, unchanged ...
+
+       let paragraph = Paragraph::new(label)
+           .style(style)
+           .alignment(Alignment::Center);
+       paragraph.render(tabs[i], buf);
+   }
+   ```
+
+   Note: `tab.label()` currently returns a `&'static str` (e.g. `"1 Connected"`). Use
+   `format!()` only when refreshing; otherwise pass the `&str` via `.to_string()` (or
+   keep the existing `Paragraph::new(label)` taking `&str` and use a `String` only for
+   the refreshing branch — both compile).
+
+5. **Update the existing tab-bar tests** (lines 107-145) — they call
+   `TabBar::new(TargetTab::Connected, true)`. Add `false, false` for the two new
+   flags:
+
+   ```rust
+   let tab_bar = TabBar::new(TargetTab::Connected, true, false, false);
+   ```
+
+   Apply the same fix to `test_tab_bar_renders_with_bootable_active` and
+   `test_tab_bar_unfocused`.
+
+6. **Add new tests:**
+
+   ```rust
+   #[test]
+   fn test_tab_bar_renders_connected_refreshing_indicator() {
+       let backend = TestBackend::new(40, 3);
+       let mut terminal = Terminal::new(backend).unwrap();
+       terminal
+           .draw(|f| {
+               let tab_bar = TabBar::new(TargetTab::Connected, true, true, false);
+               f.render_widget(tab_bar, f.area());
+           })
+           .unwrap();
+       let buffer = terminal.backend().buffer();
+       let rendered: String = buffer
+           .content()
+           .iter()
+           .map(|cell| cell.symbol())
+           .collect::<Vec<_>>()
+           .join("");
+       assert!(
+           rendered.contains("↻"),
+           "expected refresh glyph on Connected tab, got: {rendered}"
+       );
+   }
+
+   #[test]
+   fn test_tab_bar_renders_bootable_refreshing_indicator() {
+       let backend = TestBackend::new(40, 3);
+       let mut terminal = Terminal::new(backend).unwrap();
+       terminal
+           .draw(|f| {
+               let tab_bar = TabBar::new(TargetTab::Bootable, true, false, true);
+               f.render_widget(tab_bar, f.area());
+           })
+           .unwrap();
+       let buffer = terminal.backend().buffer();
+       let rendered: String = buffer
+           .content()
+           .iter()
+           .map(|cell| cell.symbol())
+           .collect::<Vec<_>>()
+           .join("");
+       assert!(rendered.contains("↻"));
+   }
+
+   #[test]
+   fn test_tab_bar_no_indicator_when_not_refreshing() {
+       let backend = TestBackend::new(40, 3);
+       let mut terminal = Terminal::new(backend).unwrap();
+       terminal
+           .draw(|f| {
+               let tab_bar = TabBar::new(TargetTab::Connected, true, false, false);
+               f.render_widget(tab_bar, f.area());
+           })
+           .unwrap();
+       let buffer = terminal.backend().buffer();
+       let rendered: String = buffer
+           .content()
+           .iter()
+           .map(|cell| cell.symbol())
+           .collect::<Vec<_>>()
+           .join("");
+       assert!(!rendered.contains("↻"));
+   }
+   ```
+
+## Acceptance Criteria
+
+- [ ] `TabBar::new()` takes four arguments: `active_tab`, `pane_focused`,
+      `connected_refreshing`, `bootable_refreshing`.
+- [ ] When `connected_refreshing` is true, the Connected tab label ends with ` ↻`.
+- [ ] When `bootable_refreshing` is true, the Bootable tab label ends with ` ↻`.
+- [ ] When both flags are false, no glyph is rendered (existing label behaviour
+      unchanged).
+- [ ] Existing tab-bar render tests pass (after their `TabBar::new()` calls are updated
+      with the two new false arguments).
+- [ ] All three new render tests pass.
+- [ ] `cargo test -p fdemon-tui --lib` passes.
+
+## Out of Scope
+
+- Updating callers of `TabBar::new()` outside this file (handled in task 06).
+- Setting the flags from the handler side (handled in task 04).

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/06-target-selector-wiring.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/06-target-selector-wiring.md
@@ -106,3 +106,32 @@ shows up end-to-end when the dialog is opened with cached data.
 
 - Modifying the `TabBar` widget itself (task 05).
 - Adding new state fields (task 02).
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-ab57294973d1149bd
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | Replaced `false, false` placeholder arguments in `TabBar::new()` with `self.state.refreshing` and `self.state.bootable_refreshing`; added 3 new render tests for glyph visibility |
+
+### Notable Decisions/Tradeoffs
+
+1. **Terminal height for render tests**: The task's sample test used a 6-row terminal which is too small for `render_full` (needs min 9 rows: 3 tab + 5 content + 1 footer). Increased to 12 rows so the tab bar area renders fully and the `↻` glyph is visible. Added a comment explaining the layout constraint.
+
+2. **Three tests instead of one**: Added `test_target_selector_renders_refreshing_glyph_when_state_set`, `test_target_selector_renders_bootable_refreshing_glyph_when_state_set`, and `test_target_selector_no_glyph_when_not_refreshing` to cover both tabs and the negative case.
+
+### Testing Performed
+
+- `cargo build --workspace` - Passed
+- `cargo test -p fdemon-tui --lib` - Passed (875 tests, 0 failures)
+- Target-selector-only run: 41 passed, 0 failed
+
+### Risks/Limitations
+
+1. **No risks**: This is a pure wiring change — replacing compile-time constants with state field reads. The `refreshing` and `bootable_refreshing` fields were already present on `TargetSelectorState` from task 02.

--- a/workflow/plans/bugs/device-cache-no-ttl/tasks/06-target-selector-wiring.md
+++ b/workflow/plans/bugs/device-cache-no-ttl/tasks/06-target-selector-wiring.md
@@ -1,0 +1,108 @@
+# Task 06 — Target Selector Passes Refreshing Flags into TabBar
+
+**Agent:** implementor
+**Phase:** 2
+**Depends on:** 02 (refreshing flags), 05 (TabBar accepts flags)
+**Files Modified (Write):** `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs`
+
+**Files Read:**
+- `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs`
+- `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs`
+
+---
+
+## Goal
+
+Update the `TargetSelector` widget so it passes
+`self.state.refreshing` and `self.state.bootable_refreshing` into the new four-arg
+`TabBar::new()` signature. This is the final wire-up — once merged, the indicator
+shows up end-to-end when the dialog is opened with cached data.
+
+## Steps
+
+1. Open `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs`.
+
+2. **Locate every `TabBar::new(...)` call** in this file (grep — there are at least
+   one or two: the main render and possibly compact-render paths). The main one is
+   around line 92:
+
+   ```rust
+   let tab_bar = TabBar::new(self.state.active_tab, self.is_focused);
+   tab_bar.render(chunks[0], buf);
+   ```
+
+3. **Update each call site** to pass the two new flags:
+
+   ```rust
+   let tab_bar = TabBar::new(
+       self.state.active_tab,
+       self.is_focused,
+       self.state.refreshing,
+       self.state.bootable_refreshing,
+   );
+   tab_bar.render(chunks[0], buf);
+   ```
+
+4. **Audit other call sites** in this file. Ensure every `TabBar::new(...)` call is
+   updated. Run a quick grep before finishing:
+
+   ```
+   grep -n "TabBar::new" crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs
+   ```
+
+5. **Update existing widget tests** in this file if any of them rely on a specific
+   tab-bar structure (most tests in this file render via `TargetSelector::render`, so
+   they exercise the wired-up behaviour automatically — no change needed beyond a
+   compile fix if a test directly constructs a `TabBar`).
+
+6. **Add an integration-style render test** that proves the indicator surfaces from
+   state through the widget:
+
+   ```rust
+   #[test]
+   fn test_target_selector_renders_refreshing_glyph_when_state_set() {
+       use ratatui::{backend::TestBackend, Terminal};
+
+       let mut state = TargetSelectorState::default();
+       state.set_connected_devices(vec![/* one device, see existing helpers */]);
+       state.refreshing = true;
+
+       let backend = TestBackend::new(60, 6);
+       let mut terminal = Terminal::new(backend).unwrap();
+       terminal
+           .draw(|f| {
+               let selector = TargetSelector::new(&state, true, &Default::default());
+               selector.render(f.area(), f.buffer_mut());
+           })
+           .unwrap();
+       let rendered: String = terminal
+           .backend()
+           .buffer()
+           .content()
+           .iter()
+           .map(|cell| cell.symbol())
+           .collect::<Vec<_>>()
+           .join("");
+       assert!(
+           rendered.contains("↻"),
+           "expected refresh glyph in target selector, got: {rendered}"
+       );
+   }
+   ```
+
+   Adjust the constructor / test-helper imports based on the actual signatures in this
+   file (use existing tests like `test_set_connected_devices` for reference patterns).
+
+## Acceptance Criteria
+
+- [ ] All `TabBar::new(...)` call sites in `target_selector.rs` pass four arguments,
+      including `self.state.refreshing` and `self.state.bootable_refreshing`.
+- [ ] `cargo build --workspace` succeeds.
+- [ ] Existing `target_selector` tests still pass.
+- [ ] New integration-style render test passes.
+- [ ] `cargo test -p fdemon-tui --lib` passes.
+
+## Out of Scope
+
+- Modifying the `TabBar` widget itself (task 05).
+- Adding new state fields (task 02).

--- a/workflow/plans/bugs/device-cache-pr37-review/BUG.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/BUG.md
@@ -1,0 +1,360 @@
+# Bugfix Plan: PR #37 Copilot Review Fixes
+
+## TL;DR
+
+Address 5 review findings from Copilot on
+[PR #37](https://github.com/edTheGuy00/fdemon/pull/37) ("fix(new-session): drop
+device-cache TTL, refresh in background"):
+
+- **F1 (Major):** When `flutter_executable()` returns `None`, the dialog stays stuck on the
+  perpetual loading spinner because `loading=true`/`bootable_loading=true` are never
+  cleared and no error is surfaced.
+- **F2 (Major):** When `connected_cached=false` but `bootable_cached=true`, the code
+  dispatches `RefreshDevicesAndBootableBackground`. A background-arm failure clears only
+  `refreshing` (not `loading`), so the Connected tab can stay stuck loading on transient
+  failure. Foreground discovery is required whenever connected cache is missing.
+- **F3 (Minor):** The doc comment on `set_error()` claims it is invoked only from the
+  connected-device foreground discovery failure path. In reality it has 13 callers
+  spanning boot failures, launch-context errors, and SDK-not-found paths. Doc-only fix.
+- **F4 (Minor):** Compact-mode tab labels render the `↻` glyph only when the refreshing
+  tab is *active*. Full-mode `TabBar` renders it per-tab regardless of active state. The
+  PR description ("Show ↻ on any tab that's refreshing") matches the full-mode behavior;
+  compact mode should match.
+- **F5 (Major):** `TargetSelector::new()` defaults `icons` to `IconSet::default()` (which
+  is Unicode). The two `TargetSelector::new(...)` call sites in
+  `widgets/new_session_dialog/mod.rs` (horizontal at line 329, vertical at line 551) do
+  not chain `.icons(*self.icons)`, so Nerd Fonts users see the Unicode `↻` glyph despite
+  having the Nerd Fonts `IconSet` configured at the dialog level.
+
+PR branch: `fix/remove-cache-device-ttl`. All fixes will be added as commits to this
+branch so the PR can land.
+
+Source review:
+[PR #37 Copilot review (id PRR_kwDOQ0IA5s744OBm)](https://github.com/edTheGuy00/fdemon/pull/37#pullrequestreview-4175487078)
+
+Parent plans:
+- [`workflow/plans/bugs/device-cache-no-ttl/BUG.md`](../device-cache-no-ttl/BUG.md)
+- [`workflow/plans/bugs/device-cache-followup/BUG.md`](../device-cache-followup/BUG.md)
+
+---
+
+## Bug Report
+
+### Symptom
+
+After PR #37 was opened, Copilot's automated review flagged five concrete issues. The
+two Major behavioral issues both produce stuck-loading states under specific (but
+realistic) conditions; the third Major issue is a cross-mode glyph regression for
+Nerd Fonts users; the two Minor issues are doc accuracy and visual consistency.
+
+1. **Open new-session dialog with no Flutter SDK configured.** Spinner spins forever
+   on both tabs; user has no recovery path inside the dialog. They must close and
+   reconfigure their `.fdemon/config.toml` blind.
+2. **Open new-session dialog with empty connected cache and populated bootable cache.**
+   `flutter devices` fails transiently. Connected tab stays stuck on the loading
+   spinner. (After follow-up task 01's fix, the `↻` indicator clears, but `loading`
+   remains true.)
+3. **`set_error()` doc misleads future maintainers.** Comment says it's called only
+   from `Message::DeviceDiscoveryFailed { is_background: false }`. Grep shows 13
+   call sites including boot failures, validation errors, launch-context errors. Risk:
+   future maintainer assumes it's safe to extend `set_error()` semantics for that single
+   path and breaks the others.
+4. **Compact mode hides the refresh indicator on inactive refreshing tabs.** Resize the
+   terminal so the dialog enters compact mode, then trigger a background bootable
+   refresh while on the Connected tab. The `↻` indicator that the full mode would show
+   on the inactive Bootable tab does not appear.
+5. **Nerd Fonts users see the wrong refresh glyph.** Configure `icon_mode = "nerd-fonts"`
+   in `.fdemon/config.toml`. Open the new-session dialog. The `↻` Unicode glyph appears
+   in the Connected/Bootable tab labels even though the user expects the Nerd Fonts
+   refresh glyph (which `TabBar` correctly resolves from `IconSet`, but only because
+   `target_selector.rs` defaults to `IconSet::default()` when no `.icons()` is chained).
+
+### Expected
+
+- Missing Flutter SDK surfaces an actionable error in the dialog and clears all
+  in-flight indicators.
+- Connected cache miss always uses foreground discovery so failures clear `loading`.
+- `set_error()` doc accurately reflects all callers and clearing semantics.
+- Compact mode and full mode show the `↻` glyph on the same tabs under the same
+  conditions.
+- Nerd Fonts users see the configured Nerd Fonts refresh glyph in tab labels.
+
+### Root Causes
+
+#### F1 — Stuck loading on missing Flutter SDK
+
+`crates/fdemon-app/src/handler/new_session/navigation.rs:243-246`:
+
+```rust
+let Some(flutter) = state.flutter_executable() else {
+    tracing::warn!("handle_open_new_session_dialog: no Flutter SDK — skipping device refresh");
+    return UpdateResult::none();
+};
+```
+
+`show_new_session_dialog()` (`state.rs:1117-1120`) reconstructs `NewSessionDialogState`
+from scratch via `NewSessionDialogState::new(configs)`, which uses
+`TargetSelectorState::default()` — and that default sets `loading: true,
+bootable_loading: true` (see `target_selector_state.rs:84-85`). When connected cache
+populates, `set_connected_devices()` clears `loading`. When bootable cache populates,
+`set_bootable_devices()` clears `bootable_loading`. But when neither cache populates
+*and* `flutter_executable()` returns `None`, neither setter is called, so both flags
+remain `true`. The dialog renders the loading spinner perpetually with no in-flight
+discovery.
+
+The other `set_error()` call site in `launch_context.rs:532` already establishes the
+pattern of surfacing this error message: `"No Flutter SDK found. Configure sdk_path
+in .fdemon/config.toml or install Flutter."`.
+
+#### F2 — Cache-miss connected-only routes failures to background arm
+
+`crates/fdemon-app/src/handler/new_session/navigation.rs:248-267`:
+
+```rust
+if connected_cached || bootable_cached {
+    // ...
+    return UpdateResult::action(UpdateAction::RefreshDevicesAndBootableBackground { flutter });
+}
+```
+
+The condition `connected_cached || bootable_cached` fires the background variant
+whenever *either* cache is hit. When `connected_cached=false` but `bootable_cached=true`:
+
+- `set_bootable_devices()` was called → `bootable_loading=false`.
+- `set_connected_devices()` was *not* called → `loading=true` (default).
+- `RefreshDevicesAndBootableBackground` is dispatched.
+- Connected discovery uses `spawn_device_discovery_background` which routes failures
+  through `Message::DeviceDiscoveryFailed { is_background: true }`. The post-task-01
+  handler arm clears `refreshing` but not `loading`.
+- Connected tab stays stuck on the loading spinner.
+
+Fix: when `connected_cached=false`, dispatch the foreground variant
+`DiscoverDevicesAndBootable` (already exists from device-cache-followup task 03). It
+uses `spawn_device_discovery` (foreground) which routes failures through `set_error()`,
+clearing `loading`. Bootable still spawns in parallel and updates the (already-shown)
+bootable list in the background.
+
+#### F3 — `set_error()` doc inaccuracy
+
+`crates/fdemon-app/src/new_session_dialog/target_selector_state.rs:271-278`:
+
+The doc comment claims `set_error()` is invoked only from
+`Message::DeviceDiscoveryFailed { is_background: false }`. Grep confirms 13 call sites:
+
+- `handler/update.rs:427` (the one the comment describes)
+- `handler/update.rs:982, 997, 1272` (session creation, boot failures)
+- `handler/new_session/target_selector.rs:170, 202` (selection / boot failures)
+- `handler/new_session/launch_context.rs:416, 430, 532, 550, 584, 608` (config /
+  launch / SDK-not-found errors)
+
+The comment must be updated to reflect that `set_error()` is a general "new-session
+error" helper, not a connected-discovery-failure-specific helper, and that
+`bootable_loading`/`bootable_refreshing` are intentionally not touched (callers that
+need to clear bootable indicators must do so themselves).
+
+#### F4 — Compact-mode glyph hidden on inactive refreshing tabs
+
+`crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs:233-252`:
+
+```rust
+let connected_label = if connected_active {
+    if self.state.refreshing {
+        format!("[1 Connected {}]", self.icons.refresh())
+    } else {
+        "[1 Connected]".to_string()
+    }
+} else {
+    "1 Connected".to_string()  // <-- no glyph if inactive, even if refreshing
+};
+```
+
+The nesting puts the `refreshing` check *inside* the `connected_active` branch, so an
+inactive tab's refreshing flag is ignored. Full-mode `TabBar` (the source of the
+PR-stated behavior) renders the glyph per-tab regardless of active state.
+
+Fix: invert the nesting — compute the base label (with/without brackets) first based on
+active state, then conditionally append the glyph based on the refreshing flag.
+
+#### F5 — `IconSet` not threaded from `NewSessionDialog` to `TargetSelector`
+
+`crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs:35-47`:
+
+```rust
+pub fn new(
+    state: &'a TargetSelectorState,
+    tool_availability: &'a ToolAvailability,
+    is_focused: bool,
+) -> Self {
+    Self {
+        state,
+        tool_availability,
+        icons: IconSet::default(),  // <-- always Unicode unless .icons() chained
+        is_focused,
+        compact: false,
+    }
+}
+```
+
+Both `TargetSelector::new()` call sites in `widgets/new_session_dialog/mod.rs` (line 329
+horizontal layout, line 551 vertical layout) do not chain `.icons(*self.icons)`, so the
+`NewSessionDialog`'s configured `IconSet` (which the user has set to Nerd Fonts via
+`config.toml`) is dropped on the floor. Result: `TabBar.icons.refresh()` returns the
+Unicode glyph instead of the Nerd Fonts glyph.
+
+Fix: chain `.icons(*self.icons)` at both call sites. (`IconSet` is `Copy` per
+`theme/icons.rs`, so `*self.icons` is a cheap copy.) Add a lock-in test in
+`new_session_dialog/mod.rs` (or `target_selector.rs`) that constructs the dialog with a
+non-default `IconSet` and asserts the rendered output contains the configured glyph.
+
+---
+
+## Affected Modules
+
+| Module | Change |
+|---|---|
+| `crates/fdemon-app/src/handler/new_session/navigation.rs` | F1: surface SDK error + clear all 4 flags on early return; F2: branch on `connected_cached` for foreground vs background routing |
+| `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | F3: rewrite `set_error()` doc to reflect actual usage and clearing semantics |
+| `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | F4: refactor compact-mode label construction so the glyph appears regardless of active state |
+| `crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs` | F5: chain `.icons(*self.icons)` at both `TargetSelector::new()` call sites; add a lock-in test |
+
+---
+
+## Phases
+
+### Phase 1 — Review fixes (single wave, all parallel)
+
+**Goal:** every Copilot review finding is addressed and verified.
+
+**Steps (per task):**
+
+1. **F1 + F2 — Stuck-loading + connected cache-miss foreground.** Replace the bare
+   `flutter_executable()` early return with a `set_error("No Flutter SDK found. ...")`
+   call plus explicit `bootable_loading = false; bootable_refreshing = false;` (since
+   `set_error()` only clears connected-side flags). Restructure the post-cache branch:
+   `if connected_cached → background (RefreshDevicesAndBootableBackground); else →
+   foreground (DiscoverDevicesAndBootable) with bootable_refreshing=true if
+   bootable_cached`. Add inline tests for both new branches.
+
+2. **F3 — `set_error()` doc accuracy.** Rewrite the doc comment using the reviewer's
+   suggested wording (or near-verbatim). Pure doc edit; no behavior change.
+
+3. **F4 — Compact-mode glyph for inactive refreshing tabs.** Refactor
+   `render_tabs_compact` so the base label (active brackets / inactive bare) is
+   computed first, then the refresh glyph is appended whenever the corresponding
+   refreshing flag is set. Mirror the `TabBar` per-tab semantics. Add a render test
+   for the inactive-tab-refreshing case.
+
+4. **F5 — Thread `IconSet` from `NewSessionDialog` to `TargetSelector`.** Add
+   `.icons(*self.icons)` chain to both `TargetSelector::new()` call sites in
+   `widgets/new_session_dialog/mod.rs` (lines 329, 551). Add a lock-in render test
+   in `mod.rs` (or extend an existing one in `target_selector.rs`) that constructs
+   the widget with a non-default `IconSet` and asserts the rendered output contains
+   the configured refresh glyph.
+
+**Measurable Outcomes:**
+
+- Opening the dialog with no Flutter SDK shows an error message ("No Flutter SDK
+  found. ...") with no spinner.
+- Opening the dialog with `connected_cached=false`, `bootable_cached=true` and a
+  failing `flutter devices` command shows a surfaced error on the Connected tab
+  (not a stuck spinner).
+- `set_error()` doc accurately describes the helper's general role and
+  bootable-flag-non-clearing semantics.
+- Compact mode shows the `↻` glyph on the inactive refreshing tab(s) just like full
+  mode does.
+- Nerd Fonts users see the Nerd Font refresh glyph in compact and full mode tabs
+  when a refresh is in flight.
+- `cargo fmt --all && cargo check --workspace && cargo test --workspace --lib && cargo clippy --workspace --lib -- -D warnings` clean.
+
+---
+
+## Edge Cases & Risks
+
+### Foreground discovery dispatched while bootable is also being discovered
+- **Scenario:** Connected cache empty, bootable cache populated. F2 fix dispatches
+  `DiscoverDevicesAndBootable` (foreground connected, background bootable).
+- **Behavior:** `bootable_refreshing=true` is set so the user sees the indicator on
+  the (already-populated) Bootable tab. Connected goes through `set_error()` on
+  failure or `set_connected_devices()` on success, both of which clear `loading`.
+  The bootable spawn updates the bootable cache in parallel.
+
+### `set_error()` called from a non-discovery path (e.g. boot failure)
+- **Risk:** F3's doc rewrite must not imply that `set_error()` clears bootable
+  indicators. Bootable discovery is independent (xcrun/emulator tools), and its
+  flags should only be cleared by their own success/failure handlers.
+- **Mitigation:** The new doc explicitly states `bootable_loading` and
+  `bootable_refreshing` are not cleared, and callers must clear them if needed.
+
+### Nerd Fonts test depends on `IconSet::default()` producing the expected glyph
+- **Risk:** F5's lock-in test must use an `IconSet` constructor that produces a
+  *different* refresh glyph than `IconSet::default()`. Otherwise the test cannot
+  distinguish "icons were threaded through" from "icons were defaulted to the same
+  thing."
+- **Mitigation:** The implementor must consult `theme/icons.rs` to confirm there's
+  a Nerd Fonts variant constructor (or build one inline via struct literal) and use
+  a glyph that differs from the Unicode `↻`.
+
+---
+
+## Out of Scope
+
+- Making `IconSet` a required constructor argument on `TargetSelector::new()`. The
+  reviewer offered both options (required arg or chain at call sites); we chose the
+  smaller-blast-radius option to minimize test churn in `target_selector.rs` (which
+  has ~6 test call sites that would all need updating).
+- Adding a real `BootableDiscoveryFailed` message variant. The current
+  `unwrap_or_default()` pattern in `spawn_bootable_device_discovery` silently hides
+  failures; surfacing them is a separate UX decision parked from the parent plan.
+- Restructuring `set_error()` to clear bootable flags too. Bootable discovery is
+  independent and its flags should be managed by their own paths.
+- Restructuring the cache-miss branching beyond what F2 requires. The new shape
+  (`if connected_cached { bg } else { fg }`) is the minimal change.
+
+---
+
+## Success Criteria
+
+### Phase 1 Complete When:
+- [ ] `flutter_executable() == None` early return calls `set_error(...)` and clears
+      `bootable_loading`/`bootable_refreshing`.
+- [ ] Test `test_open_dialog_no_flutter_sdk_surfaces_error` passes (asserts error is
+      set and all 4 flags are cleared).
+- [ ] `connected_cached=false` always dispatches `DiscoverDevicesAndBootable`
+      regardless of bootable cache state.
+- [ ] Test `test_open_dialog_bootable_cached_only_uses_foreground` passes (asserts
+      `DiscoverDevicesAndBootable` action and `bootable_refreshing=true`).
+- [ ] `set_error()` doc accurately describes general usage and bootable-flag
+      non-clearing.
+- [ ] `render_tabs_compact` shows the refresh glyph on inactive refreshing tabs.
+- [ ] Test `test_target_selector_compact_renders_refreshing_glyph_on_inactive_tab`
+      passes.
+- [ ] Both `TargetSelector::new()` call sites in `widgets/new_session_dialog/mod.rs`
+      chain `.icons(*self.icons)`.
+- [ ] Lock-in test asserts a non-default `IconSet` flows through to the rendered
+      output.
+- [ ] `cargo fmt --all && cargo check --workspace && cargo test --workspace --lib && cargo clippy --workspace --lib -- -D warnings` clean.
+
+---
+
+## Task Dependency Graph
+
+```
+Phase 1 (single wave, all parallel worktrees)
+├── 01-stuck-loading-and-cache-miss        (navigation.rs)
+├── 02-set-error-doc-accuracy              (target_selector_state.rs)
+├── 03-compact-mode-glyph-inactive-tab     (target_selector.rs)
+└── 04-thread-iconset-to-target-selector   (mod.rs)
+```
+
+No write-file overlap → all four can run in parallel worktrees.
+
+---
+
+## Milestone Deliverable
+
+When Phase 1 is complete:
+
+- All 5 Copilot review findings on PR #37 are resolved.
+- The PR is ready to land (no open review threads from Copilot's automated review).
+- Manual reviewers can verify the fixes against the original review comments at
+  https://github.com/edTheGuy00/fdemon/pull/37.

--- a/workflow/plans/bugs/device-cache-pr37-review/TASKS.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/TASKS.md
@@ -10,12 +10,12 @@ so the open PR can be merged once all fixes are pushed).
 
 ## Wave 1 — All findings (single wave, all parallel)
 
-| ID | Task | Depends on | Files Modified (Write) | Files Read |
-|---|---|---|---|---|
-| 01 | [Stuck-loading + connected cache-miss foreground (F1+F2)](tasks/01-stuck-loading-and-cache-miss.md) | — | `crates/fdemon-app/src/handler/new_session/navigation.rs` | `target_selector_state.rs`, `handler/mod.rs`, `actions/mod.rs`, `state.rs` |
-| 02 | [`set_error()` doc accuracy (F3)](tasks/02-set-error-doc-accuracy.md) | — | `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | `handler/update.rs`, `handler/new_session/launch_context.rs`, `handler/new_session/target_selector.rs` (callers, read-only) |
-| 03 | [Compact-mode glyph for inactive refreshing tabs (F4)](tasks/03-compact-mode-glyph-inactive-tab.md) | — | `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | `tab_bar.rs`, `theme/icons.rs` |
-| 04 | [Thread `IconSet` from `NewSessionDialog` to `TargetSelector` (F5)](tasks/04-thread-iconset-to-target-selector.md) | — | `crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs` | `target_selector.rs`, `theme/icons.rs` |
+| ID | Status | Task | Depends on | Files Modified (Write) | Files Read |
+|---|---|---|---|---|---|
+| 01 | [x] Done | [Stuck-loading + connected cache-miss foreground (F1+F2)](tasks/01-stuck-loading-and-cache-miss.md) | — | `crates/fdemon-app/src/handler/new_session/navigation.rs` | `target_selector_state.rs`, `handler/mod.rs`, `actions/mod.rs`, `state.rs` |
+| 02 | [x] Done | [`set_error()` doc accuracy (F3)](tasks/02-set-error-doc-accuracy.md) | — | `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | `handler/update.rs`, `handler/new_session/launch_context.rs`, `handler/new_session/target_selector.rs` (callers, read-only) |
+| 03 | [x] Done | [Compact-mode glyph for inactive refreshing tabs (F4)](tasks/03-compact-mode-glyph-inactive-tab.md) | — | `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | `tab_bar.rs`, `theme/icons.rs` |
+| 04 | [x] Done | [Thread `IconSet` from `NewSessionDialog` to `TargetSelector` (F5)](tasks/04-thread-iconset-to-target-selector.md) | — | `crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs` | `target_selector.rs`, `theme/icons.rs` |
 
 ---
 

--- a/workflow/plans/bugs/device-cache-pr37-review/TASKS.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/TASKS.md
@@ -1,0 +1,69 @@
+# Tasks: PR #37 Copilot Review Fixes
+
+Plan: [BUG.md](BUG.md)
+Source review: [PR #37 Copilot review](https://github.com/edTheGuy00/fdemon/pull/37#pullrequestreview-4175487078)
+
+**PR branch:** `fix/remove-cache-device-ttl` (commits land directly on this branch
+so the open PR can be merged once all fixes are pushed).
+
+---
+
+## Wave 1 — All findings (single wave, all parallel)
+
+| ID | Task | Depends on | Files Modified (Write) | Files Read |
+|---|---|---|---|---|
+| 01 | [Stuck-loading + connected cache-miss foreground (F1+F2)](tasks/01-stuck-loading-and-cache-miss.md) | — | `crates/fdemon-app/src/handler/new_session/navigation.rs` | `target_selector_state.rs`, `handler/mod.rs`, `actions/mod.rs`, `state.rs` |
+| 02 | [`set_error()` doc accuracy (F3)](tasks/02-set-error-doc-accuracy.md) | — | `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | `handler/update.rs`, `handler/new_session/launch_context.rs`, `handler/new_session/target_selector.rs` (callers, read-only) |
+| 03 | [Compact-mode glyph for inactive refreshing tabs (F4)](tasks/03-compact-mode-glyph-inactive-tab.md) | — | `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | `tab_bar.rs`, `theme/icons.rs` |
+| 04 | [Thread `IconSet` from `NewSessionDialog` to `TargetSelector` (F5)](tasks/04-thread-iconset-to-target-selector.md) | — | `crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs` | `target_selector.rs`, `theme/icons.rs` |
+
+---
+
+## File Overlap Analysis
+
+### Wave 1 — Overlap Matrix
+
+| Pair | Shared Write Files | Strategy |
+|---|---|---|
+| 01 ↔ 02 | none | Parallel (worktree) |
+| 01 ↔ 03 | none | Parallel (worktree) |
+| 01 ↔ 04 | none | Parallel (worktree) |
+| 02 ↔ 03 | none | Parallel (worktree) |
+| 02 ↔ 04 | none | Parallel (worktree) |
+| 03 ↔ 04 | none | Parallel (worktree) |
+
+Wave 1 has zero write-file overlap → all four tasks can run in parallel worktrees.
+
+### Read-only overlap (informational, no conflict risk)
+
+- Task 01 reads `handler/mod.rs` and `actions/mod.rs` (to confirm the existing
+  `DiscoverDevicesAndBootable` and `RefreshDevicesAndBootableBackground` variants).
+- Task 01 reads `target_selector_state.rs` (to understand `set_error()` semantics
+  for the F1 fix). Task 02 writes that file — but only the doc comment for
+  `set_error()`, not its behavior. Task 01 must use `set_error()` according to its
+  current behavior (clears `loading` and `refreshing` only; bootable flags untouched),
+  which is exactly what task 02's doc rewrite documents.
+- Task 03 reads `tab_bar.rs` (to mirror its per-tab refreshing semantics).
+- Task 04 reads `target_selector.rs` (to understand the `.icons()` builder). Task 03
+  writes that file — but only `render_tabs_compact`, not the public API. Task 04
+  uses the existing `.icons()` builder; no signature change.
+
+### Cross-task informational note
+
+- The PR branch (`fix/remove-cache-device-ttl`) already contains the
+  `DiscoverDevicesAndBootable` and `RefreshDevicesAndBootableBackground`
+  `UpdateAction` variants (added in device-cache-followup task 03 and
+  device-cache-no-ttl task 03). Task 01 wires these into the new branching shape;
+  it does **not** need to add new variants.
+
+---
+
+## Dispatch Order Summary
+
+```
+Wave 1 (parallel worktrees):  01, 02, 03, 04
+```
+
+All tasks: `Agent: implementor`. No core docs (`docs/ARCHITECTURE.md`,
+`docs/CODE_STANDARDS.md`, `docs/DEVELOPMENT.md`) require updates — this is a localized
+review-fix bundle on top of an open PR.

--- a/workflow/plans/bugs/device-cache-pr37-review/tasks/01-stuck-loading-and-cache-miss.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/tasks/01-stuck-loading-and-cache-miss.md
@@ -199,3 +199,36 @@ Key facts the implementor must know:
   remain silently swallowed by `unwrap_or_default()` (separate UX decision).
 - Restructuring the cache-population blocks earlier in the function (lines
   204-241). They are correct as-is.
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-ae9aadcc3bbe6bc44
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/handler/new_session/navigation.rs` | F1: replaced bare early return with `set_error()` + explicit bootable flag clears; F2: changed `connected_cached \|\| bootable_cached` to `if connected_cached` routing; added 3 new tests |
+| `crates/fdemon-app/src/handler/tests.rs` | Fixed `test_background_discovery_error_is_silent` to inject a fake SDK so it reaches the background path (was relying on the old silent early return) |
+
+### Notable Decisions/Tradeoffs
+
+1. **F1 error message**: Used the exact message from the task spec (`"No Flutter SDK found. Configure sdk_path in .fdemon/config.toml or install Flutter."`) matching the established pattern from `launch_context.rs:532`.
+
+2. **F2 branch restructure**: Changed `if connected_cached || bootable_cached` to `if connected_cached` as specified. The `bootable_cached`-only scenario now falls through to `DiscoverDevicesAndBootable` with `bootable_refreshing=true`, which is correct because the foreground path handles connected-discovery failures via `set_error()` (clearing `loading`).
+
+3. **Existing test fix**: `test_background_discovery_error_is_silent` in `handler/tests.rs` used `AppState::new()` without an SDK. Before this fix, the early return was silent so the dialog opened without error. After the fix, the missing SDK is surfaced as an error, breaking the test. Added `state.resolved_sdk = Some(fake_flutter_sdk())` to match the test's intent (testing background failures, not SDK-missing scenarios).
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed (1 file reformatted)
+- `cargo check -p fdemon-app` - Passed (exit code 0)
+- `cargo test -p fdemon-app --lib` - Passed (1898 tests, 0 failed)
+- `cargo clippy -p fdemon-app --lib -- -D warnings` - Passed (no warnings)
+
+### Risks/Limitations
+
+1. **SDK-missing error surfacing**: The new behavior surfaces the SDK error immediately on dialog open (not just on launch). This is strictly better UX but is a behavioral change — users with no SDK configured will now see the error in the dialog's Connected tab rather than a perpetual spinner. This aligns with the task's intent.

--- a/workflow/plans/bugs/device-cache-pr37-review/tasks/01-stuck-loading-and-cache-miss.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/tasks/01-stuck-loading-and-cache-miss.md
@@ -1,0 +1,201 @@
+# Task 01 — Stuck-Loading + Connected Cache-Miss Foreground (F1+F2)
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** none
+**Files Modified (Write):**
+- `crates/fdemon-app/src/handler/new_session/navigation.rs`
+
+---
+
+## Goal
+
+Fix two Major issues from PR #37's Copilot review, both in
+`handle_open_new_session_dialog`:
+
+- **F1:** When `flutter_executable()` returns `None`, the early return leaves
+  `loading=true`/`bootable_loading=true` (the defaults from
+  `TargetSelectorState::default()`) — the dialog spins forever with no recovery.
+- **F2:** When `connected_cached=false` but `bootable_cached=true`, the code
+  dispatches `RefreshDevicesAndBootableBackground`. A connected-discovery failure
+  on the background path clears only `refreshing` (not `loading`), so the Connected
+  tab stays stuck loading.
+
+Both findings are localized to the same function and are tightly coupled (both
+touch the post-cache-population branching), so they share a single task.
+
+## Context
+
+Current code at `crates/fdemon-app/src/handler/new_session/navigation.rs:243-274`:
+
+```rust
+let Some(flutter) = state.flutter_executable() else {
+    tracing::warn!("handle_open_new_session_dialog: no Flutter SDK — skipping device refresh");
+    return UpdateResult::none();   // F1: leaves loading=true/bootable_loading=true
+};
+
+if connected_cached || bootable_cached {
+    // F2: ALWAYS background, even when connected cache is missing
+    if connected_cached {
+        state.new_session_dialog_state.target_selector.refreshing = true;
+    }
+    if bootable_cached {
+        state.new_session_dialog_state.target_selector.bootable_refreshing = true;
+    }
+    return UpdateResult::action(UpdateAction::RefreshDevicesAndBootableBackground { flutter });
+}
+
+// Both caches empty — foreground combined discovery
+tracing::debug!("Device cache miss, triggering combined foreground+bootable discovery");
+state.new_session_dialog_state.target_selector.loading = true;
+UpdateResult::action(UpdateAction::DiscoverDevicesAndBootable { flutter })
+```
+
+Key facts the implementor must know:
+
+- `TargetSelectorState::default()` (in `target_selector_state.rs:76-90`) sets
+  `loading: true, bootable_loading: true`. `show_new_session_dialog()` uses this
+  default via `NewSessionDialogState::new(configs)`.
+- `set_error(msg)` (in `target_selector_state.rs:279-283`) clears `loading` and
+  `refreshing` but does **not** clear `bootable_loading` or `bootable_refreshing`
+  (bootable discovery is independent — see task 02 for the doc rewrite that makes
+  this explicit).
+- `UpdateAction::DiscoverDevicesAndBootable` (in `handler/mod.rs:85-95`, wired in
+  `actions/mod.rs:92-98`) spawns `spawn_device_discovery` (foreground; failures
+  route through `set_error()`) and `spawn_bootable_device_discovery` (background;
+  failures swallowed via `unwrap_or_default()`) in parallel.
+- `UpdateAction::RefreshDevicesAndBootableBackground` (in `handler/mod.rs:74-83`,
+  wired in `actions/mod.rs:85-90`) spawns the *background* connected variant
+  (failures only clear `refreshing`) plus the same bootable spawn.
+- The pattern `set_error("No Flutter SDK found. Configure sdk_path in
+  .fdemon/config.toml or install Flutter.")` is already established at
+  `handler/new_session/launch_context.rs:532`.
+
+## Steps
+
+1. **F1 — Surface SDK-missing error and clear bootable in-flight flags.**
+   Replace the bare early return with a `set_error()` call plus explicit
+   bootable-flag clears. Around line 243:
+
+   ```rust
+   let Some(flutter) = state.flutter_executable() else {
+       tracing::warn!("handle_open_new_session_dialog: no Flutter SDK — surfacing error to dialog");
+       let selector = &mut state.new_session_dialog_state.target_selector;
+       // set_error() clears `loading` and `refreshing`; bootable flags must be
+       // cleared explicitly because bootable discovery is independent of the
+       // Flutter SDK (see task 02 for the doc rewrite explaining this).
+       selector.bootable_loading = false;
+       selector.bootable_refreshing = false;
+       selector.set_error(
+           "No Flutter SDK found. Configure sdk_path in .fdemon/config.toml or install Flutter.".to_string(),
+       );
+       return UpdateResult::none();
+   };
+   ```
+
+2. **F2 — Branch on `connected_cached` rather than `connected_cached || bootable_cached`.**
+   Restructure the post-cache section so the foreground variant is used whenever
+   the connected cache is missing:
+
+   ```rust
+   if connected_cached {
+       // Connected list shown — refresh both in background. Failures on the
+       // connected side will only clear `refreshing` (not `loading`), but that's
+       // fine because `loading` is already false (set_connected_devices cleared it).
+       state.new_session_dialog_state.target_selector.refreshing = true;
+       if bootable_cached {
+           state.new_session_dialog_state.target_selector.bootable_refreshing = true;
+       }
+       return UpdateResult::action(UpdateAction::RefreshDevicesAndBootableBackground { flutter });
+   }
+
+   // Connected cache missing — foreground discovery so failures route through
+   // set_error() and clear `loading`. Bootable spawns in parallel (background).
+   if bootable_cached {
+       // Bootable already shown; mark its parallel refresh as in-flight.
+       state.new_session_dialog_state.target_selector.bootable_refreshing = true;
+   }
+   // `loading` is already true (default from show_new_session_dialog), but set
+   // explicitly for readability and to defend against future refactors.
+   state.new_session_dialog_state.target_selector.loading = true;
+   tracing::debug!(
+       "Device cache miss for connected ({}), triggering foreground combined discovery",
+       if bootable_cached { "bootable cached" } else { "neither cached" }
+   );
+   UpdateResult::action(UpdateAction::DiscoverDevicesAndBootable { flutter })
+   ```
+
+   Preserve the existing race-condition comment about close+reopen (currently at
+   `navigation.rs:252-256`); move it to the new `if connected_cached { ... }` arm
+   since the race scenario is specific to background discovery.
+
+3. **Add inline tests** in the `#[cfg(test)] mod tests` block at the bottom of
+   `navigation.rs` (the established pattern from device-cache-followup tasks). All
+   tests should follow the existing test style — use `AppState::default()`,
+   manipulate caches directly, call `handle_open_new_session_dialog`, assert on
+   `target_selector` state and the returned `UpdateResult` action.
+
+   - **`test_open_dialog_no_flutter_sdk_surfaces_error`**: configure state with no
+     SDK (i.e. `state.resolved_sdk = None` or whatever makes `flutter_executable()`
+     return `None`), call `handle_open_new_session_dialog`, assert:
+     - `target_selector.error == Some("No Flutter SDK found. Configure sdk_path in .fdemon/config.toml or install Flutter.".to_string())`
+     - `target_selector.loading == false`
+     - `target_selector.bootable_loading == false`
+     - `target_selector.refreshing == false`
+     - `target_selector.bootable_refreshing == false`
+     - The returned `UpdateResult` has no action.
+   - **`test_open_dialog_bootable_cached_only_uses_foreground`**: populate the
+     bootable cache only, leave the connected cache empty, call
+     `handle_open_new_session_dialog`, assert:
+     - The returned `UpdateResult` carries `UpdateAction::DiscoverDevicesAndBootable { .. }` (not `RefreshDevicesAndBootableBackground`).
+     - `target_selector.loading == true`
+     - `target_selector.bootable_refreshing == true`
+     - `target_selector.refreshing == false` (connected isn't refreshing — it's
+       loading from scratch).
+   - **`test_open_dialog_both_cached_uses_background`** (sanity test confirming
+     existing behaviour is preserved): populate both caches, call the handler,
+     assert `RefreshDevicesAndBootableBackground` and both `refreshing` /
+     `bootable_refreshing` are true.
+
+   Search the existing test module for similar `test_open_dialog_*` tests and use
+   the same setup helpers / assertion style. If the existing tests use a builder
+   helper for state setup, reuse it.
+
+4. **Do not modify** `set_error()` itself or `target_selector_state.rs`. Task 02
+   handles the doc comment update.
+
+5. Run verification:
+   - `cargo fmt --all`
+   - `cargo check -p fdemon-app`
+   - `cargo test -p fdemon-app --lib`
+   - `cargo clippy -p fdemon-app --lib -- -D warnings`
+
+## Acceptance Criteria
+
+- [ ] When `flutter_executable()` returns `None`, the dialog converges to a stable
+      error state: `set_error("No Flutter SDK found. ...")` is called, and
+      `bootable_loading` + `bootable_refreshing` are explicitly set to `false`.
+- [ ] The post-cache branching uses `if connected_cached` (not
+      `connected_cached || bootable_cached`) to route between background and
+      foreground discovery.
+- [ ] When `connected_cached=false` and `bootable_cached=true`, the handler
+      dispatches `UpdateAction::DiscoverDevicesAndBootable { flutter }` with
+      `bootable_refreshing=true`.
+- [ ] When both caches are populated, the handler still dispatches
+      `RefreshDevicesAndBootableBackground` with both `refreshing` and
+      `bootable_refreshing` set to `true` (no behavior regression).
+- [ ] Test `test_open_dialog_no_flutter_sdk_surfaces_error` passes.
+- [ ] Test `test_open_dialog_bootable_cached_only_uses_foreground` passes.
+- [ ] Test `test_open_dialog_both_cached_uses_background` passes (sanity).
+- [ ] `cargo test -p fdemon-app --lib` passes (no regressions in existing tests).
+- [ ] `cargo clippy -p fdemon-app --lib -- -D warnings` clean.
+
+## Out of Scope
+
+- Modifying `set_error()` itself (task 02 owns the doc rewrite for that helper).
+- Adding new `UpdateAction` variants — both `DiscoverDevicesAndBootable` and
+  `RefreshDevicesAndBootableBackground` already exist on the PR branch.
+- Adding a real `BootableDiscoveryFailed` message variant — bootable failures
+  remain silently swallowed by `unwrap_or_default()` (separate UX decision).
+- Restructuring the cache-population blocks earlier in the function (lines
+  204-241). They are correct as-is.

--- a/workflow/plans/bugs/device-cache-pr37-review/tasks/02-set-error-doc-accuracy.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/tasks/02-set-error-doc-accuracy.md
@@ -1,0 +1,127 @@
+# Task 02 — `set_error()` Doc Accuracy (F3)
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** none
+**Files Modified (Write):**
+- `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs`
+
+---
+
+## Goal
+
+Fix Minor finding F3 from PR #37's Copilot review: the doc comment on `set_error()`
+inaccurately claims the helper is invoked only from the connected-device foreground
+discovery failure path. In reality it has 13 call sites spanning boot failures,
+launch-context errors, validation failures, and SDK-not-found paths.
+
+This is a pure doc rewrite. **No behavior change.**
+
+## Context
+
+Current doc comment at
+`crates/fdemon-app/src/new_session_dialog/target_selector_state.rs:271-278`:
+
+```rust
+/// Set the connected-discovery error state.
+///
+/// Clears `loading` and `refreshing` because this is invoked only from the
+/// connected-device foreground failure path (`Message::DeviceDiscoveryFailed`
+/// with `is_background: false`). `bootable_refreshing` is intentionally **not**
+/// cleared here — bootable failures are routed through their own paths
+/// (`spawn_bootable_device_discovery` swallows errors via `unwrap_or_default()`),
+/// and clearing the bootable indicator on a connected error would be misleading.
+pub fn set_error(&mut self, error: String) {
+    self.error = Some(error);
+    self.loading = false;
+    self.refreshing = false;
+}
+```
+
+Verified callers (via `grep -rn "set_error" crates/`):
+
+- `handler/update.rs:427` — `Message::DeviceDiscoveryFailed { is_background: false }` (the only path the current doc describes)
+- `handler/update.rs:982` — session creation failure
+- `handler/update.rs:997` — session creation error
+- `handler/update.rs:1272` — boot device failure
+- `handler/new_session/target_selector.rs:170` — selection error
+- `handler/new_session/target_selector.rs:202` — boot failure from selector
+- `handler/new_session/launch_context.rs:416` — "Device no longer available"
+- `handler/new_session/launch_context.rs:430` — generic launch failure
+- `handler/new_session/launch_context.rs:532` — "No Flutter SDK found ..."
+- `handler/new_session/launch_context.rs:550` — session creation failure (launch path)
+- `handler/new_session/launch_context.rs:584` — config save error
+- `handler/new_session/launch_context.rs:608` — config save error (alternate)
+- (Plus task 01 of this plan, which adds another call from `navigation.rs` for the
+  SDK-missing path. Implementor should not assume this commit is in their worktree.)
+
+The reviewer provided suggested replacement wording in the PR comment; this task
+adopts that wording with light edits.
+
+## Steps
+
+1. Open `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` and
+   locate the `set_error()` doc comment (around line 271).
+
+2. Replace the doc comment with the following (the reviewer's suggested wording,
+   lightly edited for project tone):
+
+   ```rust
+   /// Set a new-session dialog error state.
+   ///
+   /// This helper is used by many new-session error paths, not just the
+   /// connected-device foreground discovery failure path. Callers include device
+   /// discovery failures, session creation failures, boot failures, config save
+   /// errors, "no Flutter SDK" surfaces from the launch context and dialog open,
+   /// and several validation paths.
+   ///
+   /// It records the error and clears the connected-side `loading` and
+   /// `refreshing` flags so the UI does not remain stuck in a connected
+   /// in-progress state after an error is surfaced.
+   ///
+   /// `bootable_loading` and `bootable_refreshing` are intentionally **not**
+   /// cleared here. Bootable discovery is independent (xcrun/emulator tools,
+   /// not the Flutter SDK) and its in-flight flags are managed by their own
+   /// success/failure paths. Callers that need to clear bootable indicators on
+   /// a particular error must do so themselves.
+   pub fn set_error(&mut self, error: String) {
+       self.error = Some(error);
+       self.loading = false;
+       self.refreshing = false;
+   }
+   ```
+
+3. **Do not change the function body.** Only the doc comment changes. The clearing
+   semantics (`loading` and `refreshing` cleared, bootable flags untouched) are
+   correct and intentional.
+
+4. **Do not** add or remove tests. Existing tests
+   (`test_set_error_clears_refreshing` at line 445, etc.) cover the behavior.
+
+5. Run verification:
+   - `cargo fmt --all`
+   - `cargo check -p fdemon-app`
+   - `cargo test -p fdemon-app --lib`
+   - `cargo clippy -p fdemon-app --lib -- -D warnings`
+
+## Acceptance Criteria
+
+- [ ] `set_error()`'s doc comment no longer claims the helper is invoked only from
+      `Message::DeviceDiscoveryFailed { is_background: false }`.
+- [ ] The new doc comment lists the broad categories of callers (discovery,
+      session creation, boot, launch-context, config, SDK-not-found).
+- [ ] The new doc comment explicitly states `bootable_loading` and
+      `bootable_refreshing` are not cleared and explains why (independent
+      discovery path).
+- [ ] The function body is unchanged.
+- [ ] `cargo test -p fdemon-app --lib` passes (no test changes needed).
+- [ ] `cargo clippy -p fdemon-app --lib -- -D warnings` clean.
+
+## Out of Scope
+
+- Changing `set_error()`'s clearing semantics (e.g. extending it to clear bootable
+  flags). The current behavior is correct; bootable discovery is independent.
+- Refactoring callers to a new helper (e.g. `set_error_clear_all`). Out of scope
+  per the BUG.md.
+- Adding tests for the comment wording. Doc-only changes don't warrant test
+  additions.

--- a/workflow/plans/bugs/device-cache-pr37-review/tasks/02-set-error-doc-accuracy.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/tasks/02-set-error-doc-accuracy.md
@@ -125,3 +125,32 @@ adopts that wording with light edits.
   per the BUG.md.
 - Adding tests for the comment wording. Doc-only changes don't warrant test
   additions.
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** fix/remove-cache-device-ttl
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs` | Replaced `set_error()` doc comment with accurate multi-caller description |
+
+### Notable Decisions/Tradeoffs
+
+1. **Adopted reviewer's suggested wording verbatim**: The task specified adopting the PR #37 reviewer's language with light edits. The replacement comment accurately lists the broad caller categories and explicitly names both `bootable_loading` and `bootable_refreshing` as intentionally not cleared.
+2. **No behavior change**: The function body (`self.error = Some(error); self.loading = false; self.refreshing = false;`) was not touched.
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed (no changes needed)
+- `cargo check -p fdemon-app` - Passed
+- `cargo test -p fdemon-app --lib` - Passed (1895 tests, 0 failed)
+- `cargo clippy -p fdemon-app --lib -- -D warnings` - Passed (clean)
+
+### Risks/Limitations
+
+1. **None**: This is a pure doc rewrite with no semantic changes. All acceptance criteria are met.

--- a/workflow/plans/bugs/device-cache-pr37-review/tasks/03-compact-mode-glyph-inactive-tab.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/tasks/03-compact-mode-glyph-inactive-tab.md
@@ -142,3 +142,33 @@ the glyph.
   task 04).
 - Adding new public APIs to `TargetSelector` or new builder methods. The fix is
   internal to `render_tabs_compact`.
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-a969ce4f369774621
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` | Refactored `render_tabs_compact` label construction to separate base-label (brackets vs bare) from glyph appending; added `test_target_selector_compact_renders_refreshing_glyph_on_inactive_tab` test |
+
+### Notable Decisions/Tradeoffs
+
+1. **Two-block test structure**: The new test uses two inner scopes (Case 1 and Case 2) within a single `#[test]` function as suggested in the task, providing clear diagnostic messages for each scenario while keeping the test count tidy.
+2. **No change to active-tab behavior**: The refactored label construction preserves the `[brackets]` for the active tab and bare text for the inactive tab, just reorders the nesting so the glyph check is outer.
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed
+- `cargo check -p fdemon-tui` - Passed
+- `cargo test -p fdemon-tui --lib` - Passed (877 tests)
+- `cargo clippy -p fdemon-tui --lib -- -D warnings` - Passed (clean)
+- `cargo test -p fdemon-tui --lib "target_selector"` - Passed (44 tests, including new inactive-tab test)
+
+### Risks/Limitations
+
+1. **None**: The change is purely internal to `render_tabs_compact`; no public API was modified and no layer boundaries were touched.

--- a/workflow/plans/bugs/device-cache-pr37-review/tasks/03-compact-mode-glyph-inactive-tab.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/tasks/03-compact-mode-glyph-inactive-tab.md
@@ -1,0 +1,144 @@
+# Task 03 — Compact-Mode Glyph for Inactive Refreshing Tabs (F4)
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** none
+**Files Modified (Write):**
+- `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs`
+
+---
+
+## Goal
+
+Fix Minor finding F4 from PR #37's Copilot review: in compact mode, the `↻` refresh
+glyph appears only when the *refreshing tab is the active tab*. Full mode (`TabBar`)
+shows the glyph per-tab regardless of active state, matching the PR description.
+Compact mode should match.
+
+## Context
+
+Current code at
+`crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs:233-252`:
+
+```rust
+let connected_label = if connected_active {
+    if self.state.refreshing {
+        format!("[1 Connected {}]", self.icons.refresh())
+    } else {
+        "[1 Connected]".to_string()
+    }
+} else {
+    "1 Connected".to_string()  // <-- no glyph if inactive, even if refreshing
+};
+
+let bootable_label = if bootable_active {
+    if self.state.bootable_refreshing {
+        format!("[2 Bootable {}]", self.icons.refresh())
+    } else {
+        "[2 Bootable]".to_string()
+    }
+} else {
+    "2 Bootable".to_string()  // <-- same problem
+};
+```
+
+The nesting puts the `refreshing` check *inside* the `*_active` branch, so the
+inactive case never appends the glyph. Full-mode `TabBar` (in `tab_bar.rs`) computes
+the glyph independently from active state.
+
+Reviewer's suggested replacement (in the PR comment) inverts the nesting: compute
+the base label first (with active-tab brackets or bare), then conditionally append
+the glyph.
+
+## Steps
+
+1. Open `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs` and
+   locate `render_tabs_compact` (around line 220).
+
+2. Replace the label-construction block (currently lines 233-252) with the
+   refactored version:
+
+   ```rust
+   // Build the base label (active-tab brackets vs bare), then conditionally
+   // append the refresh glyph for any tab whose refresh is in flight. This
+   // mirrors `TabBar`'s per-tab semantics in full mode.
+   let connected_base = if connected_active {
+       "[1 Connected]"
+   } else {
+       "1 Connected"
+   };
+   let connected_label = if self.state.refreshing {
+       format!("{} {}", connected_base, self.icons.refresh())
+   } else {
+       connected_base.to_string()
+   };
+
+   let bootable_base = if bootable_active {
+       "[2 Bootable]"
+   } else {
+       "2 Bootable"
+   };
+   let bootable_label = if self.state.bootable_refreshing {
+       format!("{} {}", bootable_base, self.icons.refresh())
+   } else {
+       bootable_base.to_string()
+   };
+   ```
+
+3. **Add a render test** in the `#[cfg(test)] mod tests` block at the bottom of
+   `target_selector.rs`. Mirror the existing test
+   `test_target_selector_compact_renders_refreshing_glyph` (added in
+   device-cache-followup task 04) but for the *inactive* tab case:
+
+   - **`test_target_selector_compact_renders_refreshing_glyph_on_inactive_tab`**:
+     - Build a `TargetSelectorState` with `bootable_refreshing = true` and
+       `active_tab = TargetTab::Connected` (so Bootable is the inactive,
+       refreshing tab).
+     - Render `TargetSelector::new(...).compact(true)` into a small buffer.
+     - Convert the buffer to a string (use the existing buffer-to-string helper if
+       present in the test module, e.g. `buffer_to_string` or inline iteration).
+     - Assert the rendered output contains `IconSet::default().refresh()` (which
+       resolves to `"\u{21bb}"`, i.e. `"↻"`).
+     - Use a diagnostic assertion message: `"expected refresh glyph on inactive
+       Bootable tab in compact mode, got: {rendered}"`.
+     - Symmetric variant: `connected_active = false` (i.e. set
+       `active_tab = TargetTab::Bootable`) with `refreshing = true` — assert the
+       glyph appears next to the inactive Connected label too. Combine into one
+       test or split into two; one combined test is fine if the assertion is clear.
+
+4. **Do not change** `render_full` or `TabBar`. Full-mode rendering is correct.
+
+5. **Do not change** `target_selector.rs:35-56` (`new`, `icons`, `compact`
+   builders). Task 04 handles `IconSet` threading separately.
+
+6. Run verification:
+   - `cargo fmt --all`
+   - `cargo check -p fdemon-tui`
+   - `cargo test -p fdemon-tui --lib`
+   - `cargo clippy -p fdemon-tui --lib -- -D warnings`
+
+## Acceptance Criteria
+
+- [ ] `render_tabs_compact` computes base labels first (active-tab brackets vs
+      bare) then conditionally appends the refresh glyph based on each tab's
+      `*_refreshing` flag, regardless of active state.
+- [ ] When the active tab is Connected and `bootable_refreshing == true`, the
+      rendered compact output contains the refresh glyph next to the Bootable
+      label.
+- [ ] Symmetric: when the active tab is Bootable and `refreshing == true`, the
+      rendered compact output contains the glyph next to the Connected label.
+- [ ] Existing test `test_target_selector_compact_renders_refreshing_glyph`
+      (active-tab case) still passes unchanged — the new label-construction logic
+      preserves the active-tab + refreshing glyph behavior.
+- [ ] New test `test_target_selector_compact_renders_refreshing_glyph_on_inactive_tab`
+      passes.
+- [ ] `cargo test -p fdemon-tui --lib` passes (no regressions).
+- [ ] `cargo clippy -p fdemon-tui --lib -- -D warnings` clean.
+
+## Out of Scope
+
+- Modifying `TabBar` or `render_full`. Full-mode rendering is correct.
+- Threading `IconSet` from `NewSessionDialog` to `TargetSelector` (owned by
+  task 04).
+- Adding new public APIs to `TargetSelector` or new builder methods. The fix is
+  internal to `render_tabs_compact`.

--- a/workflow/plans/bugs/device-cache-pr37-review/tasks/04-thread-iconset-to-target-selector.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/tasks/04-thread-iconset-to-target-selector.md
@@ -205,3 +205,37 @@ chaining; if it's not `Copy`, use `.clone()` instead of `*`). The fix is to chai
 - Threading `IconSet` to other child widgets (`LaunchContextWithDevice` already
   receives `self.icons` per `mod.rs:346` and `mod.rs:570` — verify, don't touch).
 - Rewriting the `IconSet` type or its constructors.
+
+---
+
+## Completion Summary
+
+**Status:** Done
+**Branch:** worktree-agent-a96dd1e525b9e7ff5
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs` | Added `.icons(*self.icons)` chain to both `TargetSelector::new()` call sites (horizontal at line ~329 and vertical at line ~551); added two lock-in render tests |
+
+### Notable Decisions/Tradeoffs
+
+1. **IconSet is Copy**: Confirmed `IconSet` derives `Copy` (line 13 of `theme/icons.rs`), so used `*self.icons` (dereference copy) instead of `.clone()`.
+
+2. **Vertical test ordering**: `set_bootable_devices()` resets `bootable_refreshing` to `false` (line 254 of `target_selector_state.rs`), so the test must set `bootable_refreshing = true` AFTER calling `set_bootable_devices()` — not before. Initial test had the order reversed, causing the glyph to not appear.
+
+3. **Two lock-in tests**: Added both horizontal and vertical tests as the task specified both paths. The vertical test uses `bootable_refreshing = true` with `active_tab = Bootable` to distinguish the NerdFonts glyph from Unicode in the compact tab bar rendered by `render_tabs_compact`.
+
+4. **LaunchContextWithDevice verified untouched**: Both call sites at ~line 346 and ~line 570 already chain `self.icons` to `LaunchContextWithDevice::new()` — confirmed out of scope, not modified.
+
+### Testing Performed
+
+- `cargo fmt --all` - Passed (auto-formatted)
+- `cargo check -p fdemon-tui` - Passed
+- `cargo test -p fdemon-tui --lib` - Passed (878 tests, 2 new)
+- `cargo clippy -p fdemon-tui --lib -- -D warnings` - Passed (clean)
+
+### Risks/Limitations
+
+1. **NerdFonts glyph in test terminal**: The NerdFonts glyph `\u{f021}` is from the Private Use Area. The test correctly checks for its presence using `rendered.contains(nerd_refresh)` which works regardless of terminal font support since it operates on the raw string data in the Ratatui `TestBackend` buffer.

--- a/workflow/plans/bugs/device-cache-pr37-review/tasks/04-thread-iconset-to-target-selector.md
+++ b/workflow/plans/bugs/device-cache-pr37-review/tasks/04-thread-iconset-to-target-selector.md
@@ -1,0 +1,207 @@
+# Task 04 — Thread `IconSet` from `NewSessionDialog` to `TargetSelector` (F5)
+
+**Agent:** implementor
+**Phase:** 1
+**Depends on:** none
+**Files Modified (Write):**
+- `crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs`
+
+---
+
+## Goal
+
+Fix Major finding F5 from PR #37's Copilot review: `TargetSelector::new()` defaults
+its internal `icons` field to `IconSet::default()` (Unicode). The two
+`TargetSelector::new()` call sites in `widgets/new_session_dialog/mod.rs` do not
+chain `.icons(*self.icons)`, so the `NewSessionDialog`'s configured `IconSet` (which
+the user set to Nerd Fonts via `.fdemon/config.toml`) is dropped. Result: Nerd Fonts
+users see the Unicode `↻` glyph in tab labels even though `TabBar` correctly
+resolves the Nerd Fonts glyph from a properly-configured `IconSet`.
+
+## Context
+
+`NewSessionDialog` already holds an `&IconSet` (see
+`widgets/new_session_dialog/mod.rs:158-182`):
+
+```rust
+pub struct NewSessionDialog<'a> {
+    state: &'a NewSessionDialogState,
+    tool_availability: &'a ToolAvailability,
+    icons: &'a IconSet,
+}
+```
+
+`TargetSelector` exposes a builder method for the icon set (see
+`widgets/new_session_dialog/target_selector.rs:49-56`):
+
+```rust
+/// Set the icon set for this widget (builder pattern).
+///
+/// Callers that have a configured `IconSet` (e.g. from `NewSessionDialog`)
+/// should pass it here to ensure Nerd Font glyphs are used when configured.
+pub fn icons(mut self, icons: IconSet) -> Self {
+    self.icons = icons;
+    self
+}
+```
+
+The two un-chained call sites in `mod.rs`:
+
+- **Line 329 (horizontal layout):**
+
+  ```rust
+  let target_selector = TargetSelector::new(
+      &self.state.target_selector,
+      self.tool_availability,
+      target_focused,
+  );
+  target_selector.render(chunks[0], buf);
+  ```
+
+- **Line 551 (vertical layout):**
+
+  ```rust
+  let target_selector = TargetSelector::new(
+      &self.state.target_selector,
+      self.tool_availability,
+      target_focused,
+  )
+  .compact(target_compact);
+  target_selector.render(chunks[2], buf);
+  ```
+
+`IconSet` is `Copy` (verified by inspecting `theme/icons.rs` — confirm before
+chaining; if it's not `Copy`, use `.clone()` instead of `*`). The fix is to chain
+`.icons(*self.icons)` (or `.icons(self.icons.clone())`) to both call sites.
+
+## Steps
+
+1. **Inspect `theme/icons.rs`** to confirm `IconSet` is `Copy`. If yes, chain
+   `.icons(*self.icons)`. If no, chain `.icons(self.icons.clone())` (acceptable
+   given it's tiny — a few enum-variant-like fields).
+
+2. Open `crates/fdemon-tui/src/widgets/new_session_dialog/mod.rs` and locate the
+   horizontal-layout call (around line 329). Add the `.icons(...)` chain:
+
+   ```rust
+   let target_selector = TargetSelector::new(
+       &self.state.target_selector,
+       self.tool_availability,
+       target_focused,
+   )
+   .icons(*self.icons);  // or .clone() if IconSet is not Copy
+   target_selector.render(chunks[0], buf);
+   ```
+
+3. Locate the vertical-layout call (around line 551) and add the chain there too:
+
+   ```rust
+   let target_selector = TargetSelector::new(
+       &self.state.target_selector,
+       self.tool_availability,
+       target_focused,
+   )
+   .icons(*self.icons)
+   .compact(target_compact);
+   target_selector.render(chunks[2], buf);
+   ```
+
+   The order of `.icons()` and `.compact()` is irrelevant since both return `Self`,
+   but keep `.icons()` first for consistency with the horizontal layout.
+
+4. **Add a lock-in render test.** The test must construct a `NewSessionDialog`
+   with a non-default `IconSet` (one that produces a *different* refresh glyph
+   from `IconSet::default()`) and assert the rendered output contains the
+   non-default glyph. This proves the icon set flows through to the tab bar.
+
+   Pseudocode (the implementor should consult `theme/icons.rs` for the actual
+   constructor — likely something like `IconSet::nerd_fonts()` or a struct literal
+   `IconSet { mode: IconMode::NerdFonts, .. }`):
+
+   ```rust
+   #[test]
+   fn test_new_session_dialog_threads_iconset_to_target_selector() {
+       use crate::theme::icons::{IconMode, IconSet};
+
+       // Build a non-default icon set whose refresh glyph differs from the
+       // default.
+       let nerd_icons = IconSet { mode: IconMode::NerdFonts /* + any other fields */ };
+       assert_ne!(
+           nerd_icons.refresh(),
+           IconSet::default().refresh(),
+           "test setup error: nerd_icons.refresh() must differ from default"
+       );
+
+       let mut state = NewSessionDialogState::default();
+       state.target_selector.refreshing = true;  // ensure the glyph is rendered
+
+       let tool_availability = ToolAvailability::default();
+       let dialog = NewSessionDialog::new(&state, &tool_availability, &nerd_icons);
+
+       // Render into a buffer sized for full (horizontal) layout
+       let area = Rect::new(0, 0, 120, 30);
+       let mut buf = Buffer::empty(area);
+       dialog.render(area, &mut buf);
+
+       let rendered = buffer_to_string(&buf);  // use existing helper if present
+       assert!(
+           rendered.contains(nerd_icons.refresh()),
+           "expected NerdFonts refresh glyph in rendered tabs, got: {rendered}"
+       );
+       assert!(
+           !rendered.contains(IconSet::default().refresh()),
+           "default Unicode glyph must NOT appear when NerdFonts is configured, got: {rendered}"
+       );
+   }
+   ```
+
+   Notes for the implementor:
+   - Inspect existing tests in `mod.rs` and `target_selector.rs` for the
+     buffer-to-string helper and `Rect`/`Buffer` setup pattern.
+   - If `IconMode::NerdFonts.refresh()` happens to equal Unicode (i.e. they share
+     a refresh glyph), pick a different glyph (e.g. `IconSet { mode: IconMode::Ascii }`
+     if that exists and produces a distinct refresh value) and assert on that.
+     The point is: the test must distinguish "default" from "configured."
+   - If no non-default `IconSet` constructor produces a distinct refresh glyph,
+     STOP and report — the test as designed cannot prove the bug is fixed and
+     the fix becomes unverifiable from the TUI layer. (This would be unusual:
+     `theme/icons.rs:96` is documented to expose distinct Nerd Font and Unicode
+     refresh glyphs.)
+
+5. Add a similar test for the **vertical (compact) layout** if practical: render
+   into a buffer that triggers the vertical layout, configure
+   `bootable_refreshing = true`, assert the configured glyph appears. If the
+   compact-layout test is too plumbing-heavy, a single horizontal-layout test is
+   acceptable as a lock-in (the compact path uses the same threading and the
+   compile-time chain is verified by the source change itself).
+
+6. Run verification:
+   - `cargo fmt --all`
+   - `cargo check -p fdemon-tui`
+   - `cargo test -p fdemon-tui --lib`
+   - `cargo clippy -p fdemon-tui --lib -- -D warnings`
+
+## Acceptance Criteria
+
+- [ ] Both `TargetSelector::new()` call sites in
+      `widgets/new_session_dialog/mod.rs` (horizontal at ~line 329, vertical at
+      ~line 551) chain `.icons(*self.icons)` (or `.clone()`).
+- [ ] New lock-in test
+      `test_new_session_dialog_threads_iconset_to_target_selector` (or
+      similarly-named) constructs a `NewSessionDialog` with a non-default
+      `IconSet` and asserts the configured (non-Unicode) refresh glyph appears in
+      the rendered output.
+- [ ] The lock-in test also asserts the default Unicode glyph does **not** appear
+      when a non-default `IconSet` is configured (proves the threading is real,
+      not a fallback).
+- [ ] `cargo test -p fdemon-tui --lib` passes.
+- [ ] `cargo clippy -p fdemon-tui --lib -- -D warnings` clean.
+
+## Out of Scope
+
+- Making `IconSet` a required constructor argument on `TargetSelector::new()`
+  (per BUG.md, this is rejected to minimize test churn in `target_selector.rs`).
+- Modifying `TargetSelector` itself or its `.icons()` builder.
+- Threading `IconSet` to other child widgets (`LaunchContextWithDevice` already
+  receives `self.icons` per `mod.rs:346` and `mod.rs:570` — verify, don't touch).
+- Rewriting the `IconSet` type or its constructors.

--- a/workflow/reviews/bugs/device-cache-no-ttl/ACTION_ITEMS.md
+++ b/workflow/reviews/bugs/device-cache-no-ttl/ACTION_ITEMS.md
@@ -1,0 +1,133 @@
+# Action Items: Device Cache No-TTL
+
+**Review Date:** 2026-04-25
+**Verdict:** ⚠️ NEEDS WORK
+**Blocking Issues:** 1 critical, 2 major
+
+---
+
+## Critical Issues (Must Fix)
+
+### 1. Clear `refreshing` flag on background discovery failure
+
+- **Source:** `bug_fix_reviewer`, `architecture_enforcer`, `logic_reasoning_checker` (all flagged independently)
+- **File:** `crates/fdemon-app/src/handler/update.rs:405-428`
+- **Problem:** `Message::DeviceDiscoveryFailed { is_background: true }` only logs the warning;
+  it does not clear `state.new_session_dialog_state.target_selector.refreshing`. Since the new
+  `RefreshDevicesAndBootableBackground` action sends background failures through this exact
+  path, any transient `flutter devices` failure leaves the `↻` glyph stuck on the Connected
+  tab until the dialog is closed and reopened. BUG.md's "Cache Becoming Severely Stale"
+  mitigation note (line 191) explicitly — and incorrectly — claims `set_error()` handles
+  this case.
+- **Required Action:** in the `is_background: true` arm, clear the flag when the dialog is
+  visible:
+  ```rust
+  if is_background {
+      tracing::warn!("Background device refresh failed: {}", error);
+      if state.ui_mode == UiMode::NewSessionDialog || state.ui_mode == UiMode::Startup {
+          state.new_session_dialog_state.target_selector.refreshing = false;
+      }
+  }
+  ```
+  Also update BUG.md line 191 to reflect the actual clearing path.
+- **Acceptance:** new test in `handler/tests.rs` — open dialog with cached devices, force
+  `Message::DeviceDiscoveryFailed { is_background: true }`, assert `refreshing == false`.
+
+---
+
+## Major Issues (Should Fix)
+
+### 2. Cache-miss fallback never triggers bootable discovery
+
+- **Source:** `code_quality_inspector`, `logic_reasoning_checker`
+- **File:** `crates/fdemon-app/src/handler/new_session/navigation.rs:258-261`
+- **Problem:** When both caches are empty, only `UpdateAction::DiscoverDevices` is dispatched.
+  `DiscoverDevices` spawns a connected-device discovery only — bootable discovery is not
+  triggered. The Bootable tab will sit at `bootable_loading = true` until the user manually
+  switches tabs. This contradicts the milestone deliverable: "Both connected and bootable
+  lists are refreshed on every dialog open."
+- **Suggested Action:** in the cache-miss branch, after `loading = true`, also dispatch the
+  combined background refresh, or extend `DiscoverDevices` to spawn both. Option A:
+  ```rust
+  // both caches empty: foreground discovery + parallel background bootable
+  state.new_session_dialog_state.target_selector.loading = true;
+  // (chain DiscoverDevices and a bootable refresh, or replace with a new "discover both" action)
+  ```
+- **Acceptance:** new test in `navigation.rs` covering "open dialog with no caches → both
+  connected and bootable discoveries are kicked off."
+
+### 3. `get_cached_bootable_devices()` clones the cache on every call
+
+- **Source:** `code_quality_inspector`
+- **File:** `crates/fdemon-app/src/state.rs:1261-1265`
+- **Problem:** Returns `Option<(Vec<IosSimulator>, Vec<AndroidAvd>)>`, forcing a clone of both
+  Vecs on every dialog open even when devices are unchanged. The connected-device equivalent
+  returns a reference and clones at the single call site.
+- **Suggested Action:** change return to
+  `Option<(&Vec<IosSimulator>, &Vec<AndroidAvd>)>`; let the call site in `navigation.rs:228-234`
+  clone explicitly when it forwards into `set_bootable_devices`.
+- **Acceptance:** the function returns references; existing tests still pass.
+
+---
+
+## Minor Issues (Consider Fixing)
+
+### 4. Add symmetric test for `BootableDevicesDiscovered` clearing `bootable_refreshing`
+- **File:** `crates/fdemon-app/src/handler/tests.rs`
+- The connected side has `test_devices_discovered_clears_refreshing`; mirror it for the
+  bootable side.
+
+### 5. Extract `↻` to a named constant
+- **File:** `crates/fdemon-tui/src/widgets/new_session_dialog/tab_bar.rs`
+- Add `const REFRESHING_GLYPH: &str = "↻";` and reference from the render loop. Update test
+  assertions in `tab_bar.rs` and `target_selector.rs` to reference the constant.
+
+### 6. Document or fix `set_error()` asymmetric clearing
+- **File:** `crates/fdemon-app/src/new_session_dialog/target_selector_state.rs:271-276`
+- Either add a comment explaining why only `refreshing` is cleared (and not `bootable_refreshing`),
+  or clear both for consistency with the symmetric flag design.
+
+### 7. Render `↻` indicator in compact mode
+- **File:** `crates/fdemon-tui/src/widgets/new_session_dialog/target_selector.rs`
+- `render_tabs_compact` doesn't surface the refresh state. Add a small inline indicator or
+  document the omission.
+
+### 8. Comment the close+reopen race
+- **File:** `crates/fdemon-app/src/handler/new_session/navigation.rs` near `refreshing = true`
+- Briefly note that an in-flight discovery from a prior dialog session may clear the new
+  flag prematurely if the close+reopen happens fast.
+
+### 9. Resolve or ticket the stale TODO at `target_selector_state.rs:455`
+- "deduplicate with device_list::calculate_scroll_offset — move to fdemon-core" — pre-existing,
+  but visible in modified-file scope.
+
+### 10. Collapse the dead branch in `handle_close_new_session_dialog`
+- **File:** `crates/fdemon-app/src/handler/new_session/navigation.rs:264-279`
+- Both arms of the `if has_running_sessions` set `UiMode::Normal`; the misleading comment
+  says "stay in startup mode" but doesn't.
+
+### 11. Confirm indicator-on-inactive-tab semantics
+- The implementation shows `↻` on every tab whose flag is true, regardless of active. This
+  matches BUG.md but worth a quick "yes that's what we want" before considering it final.
+
+---
+
+## Nitpicks
+
+- Multi-line the `RefreshDevicesAndBootableBackground` enum variant with a field-level
+  `///` doc to match siblings (`handler/mod.rs`).
+- Add an assertion message to `test_tab_bar_renders_bootable_refreshing_indicator`.
+- Extract `cached_devices.len()` to a local before `.clone()` in `navigation.rs` for clarity.
+
+---
+
+## Re-review Checklist
+
+After addressing issues:
+
+- [ ] All Critical issues resolved
+- [ ] All Major issues resolved or explicitly documented as out-of-scope
+- [ ] At least minor items 4, 5, 6 addressed
+- [ ] BUG.md updated to reflect the corrected clearing semantics
+- [ ] `cargo fmt --all && cargo check --workspace && cargo test --workspace --lib && cargo clippy --workspace --lib -- -D warnings` passes
+- [ ] New tests added for: background-failure flag clearing (C1), both-cache-empty bootable discovery (M2)

--- a/workflow/reviews/bugs/device-cache-no-ttl/REVIEW.md
+++ b/workflow/reviews/bugs/device-cache-no-ttl/REVIEW.md
@@ -1,0 +1,238 @@
+# Review: Device Cache Drops After 30s (Issue #33 follow-up)
+
+**Review Date:** 2026-04-25
+**Diff Range:** `06202d7..HEAD` (commits `5d52f80`, `9be6b9a`, `b530f7f`, `e96eb4f`, `aef9136`, `87ac4be`)
+**Plan:** [`workflow/plans/bugs/device-cache-no-ttl/BUG.md`](../../../plans/bugs/device-cache-no-ttl/BUG.md)
+**Tasks:** 6 (all merged)
+**Files Changed:** 8 (+391 / -70)
+
+---
+
+## Verdict: ⚠️ NEEDS WORK
+
+The fix is functionally correct for the stated symptom — cached devices now appear instantly regardless of elapsed time, and the `↻` indicator wires through cleanly. However, three independent reviewers (`bug_fix_reviewer`, `architecture_enforcer`, `logic_reasoning_checker`) flagged the same concrete logic gap that contradicts an explicit mitigation in BUG.md, plus a meaningful behavioural gap in the cache-miss path. These should be addressed before this is considered "done done."
+
+| Reviewer | Verdict |
+|---|---|
+| `bug_fix_reviewer` | ✅ Approved with observations |
+| `architecture_enforcer` | ✅ PASS |
+| `code_quality_inspector` | ⚠️ NEEDS WORK |
+| `logic_reasoning_checker` | ⚠️ CONCERN (one finding labeled Critical) |
+
+Two CONCERN-tier verdicts → overall **NEEDS WORK** per the consolidation rule.
+
+---
+
+## Critical Findings (must fix)
+
+### 🔴 C1. Background discovery failure leaves `refreshing` flag stuck
+
+[Sources: `bug_fix_reviewer` Warning 2, `architecture_enforcer` Recommendation 3, `logic_reasoning_checker` Critical #1]
+
+**File:** `crates/fdemon-app/src/handler/update.rs:405-428`
+
+`Message::DeviceDiscoveryFailed { is_background: true }` only logs a warning. It never touches
+`state.new_session_dialog_state.target_selector.refreshing`:
+
+```rust
+if is_background {
+    tracing::warn!("Background device refresh failed: {}", error);  // ← stops here
+} else {
+    if state.ui_mode == UiMode::Startup || state.ui_mode == UiMode::NewSessionDialog {
+        state.new_session_dialog_state.target_selector.set_error(error.clone());
+    }
+    tracing::error!("Device discovery failed: {}", error);
+}
+```
+
+Since the new `RefreshDevicesAndBootableBackground` action calls
+`spawn_device_discovery_background` (which sends `is_background: true` on failure), every transient
+`flutter devices` failure leaves `refreshing = true` indefinitely. The `↻` glyph stays stuck on
+the Connected tab until either (a) a subsequent successful discovery arrives, or (b) the dialog is
+closed and reopened.
+
+The BUG.md "Cache Becoming Severely Stale" section explicitly claims this case is handled:
+
+> The `refreshing` indicator clears even on failure (handled by `set_error()` clearing `refreshing`).
+
+This claim is false for the dominant failure path. `set_error()` is only reached in the
+foreground branch.
+
+**Required fix:** in the `is_background: true` arm, clear the flag (guarded by dialog visibility):
+
+```rust
+if is_background {
+    tracing::warn!("Background device refresh failed: {}", error);
+    if state.ui_mode == UiMode::NewSessionDialog || state.ui_mode == UiMode::Startup {
+        state.new_session_dialog_state.target_selector.refreshing = false;
+    }
+}
+```
+
+---
+
+## Major Findings (should fix)
+
+### 🟠 M1. Cache-miss fallback never refreshes the bootable list
+
+[Sources: `code_quality_inspector` MAJOR 2, `logic_reasoning_checker` Warning 4]
+
+**File:** `crates/fdemon-app/src/handler/new_session/navigation.rs:258-261`
+
+When **both** caches are empty, the handler dispatches only `UpdateAction::DiscoverDevices`,
+which spawns a connected-device discovery only (`actions/mod.rs:75-77`). Bootable discovery is
+not triggered — it relies on the one-shot `ToolAvailabilityChecked` message from engine startup
+or on the user manually switching to the Bootable tab.
+
+This contradicts the milestone deliverable in BUG.md:
+
+> Both connected and bootable lists are refreshed on every dialog open, eliminating the latent
+> bug where bootable devices were frozen after startup.
+
+On a first dialog open after startup tool-availability has fired, the Bootable tab will sit at
+its default `bootable_loading = true` state until the user switches tabs.
+
+**Suggested fix:** in the cache-miss fallback, dispatch the combined refresh in addition to
+the foreground `DiscoverDevices`, or extend the action to spawn both.
+
+### 🟠 M2. `get_cached_bootable_devices()` clones the entire bootable cache on every call
+
+[Source: `code_quality_inspector` MAJOR 1]
+
+**File:** `crates/fdemon-app/src/state.rs:1261-1265`
+
+```rust
+pub fn get_cached_bootable_devices(&self) -> Option<(Vec<IosSimulator>, Vec<AndroidAvd>)>
+```
+
+The owned-return signature forces the function body to clone both Vecs unconditionally on every
+dialog open. The connected-device equivalent (`get_cached_devices`) returns
+`Option<&Vec<Device>>`, which makes the clone explicit at the call site (currently a single
+`.clone()` in `navigation.rs:214`).
+
+The asymmetry hides a non-trivial allocation in a path the BUG.md explicitly markets as
+"shows the cached list instantly."
+
+**Suggested fix:** change the return to
+`Option<(&Vec<IosSimulator>, &Vec<AndroidAvd>)>` and clone at the single call site, mirroring
+the connected-device pattern.
+
+---
+
+## Minor Findings (consider fixing)
+
+### 🟡 m1. Missing test: `BootableDevicesDiscovered` clearing `bootable_refreshing`
+[Source: `bug_fix_reviewer` Warning 1] — Task 04 added `test_devices_discovered_clears_refreshing`
+for the connected side but no symmetric test was added for the bootable side. The mechanism is
+correct by construction, but a regression introduced by adding a guard before
+`set_bootable_devices()` would go undetected.
+
+### 🟡 m2. Hardcoded `↻` glyph (no named constant)
+[Source: `code_quality_inspector` MINOR 3] — `tab_bar.rs:71` and 6+ test assertions across
+`tab_bar.rs` and `target_selector.rs` reference the literal `"↻"`. BUG.md's own
+"Indicator Glyph Compatibility" risk recommends a possible swap to `*` or `…`. Today that swap
+requires touching every test. A `const REFRESHING_GLYPH: &str = "↻"` makes it a one-liner.
+
+### 🟡 m3. `set_error()` asymmetrically clears `refreshing` but not `bootable_refreshing`
+[Sources: `code_quality_inspector` / `logic_reasoning_checker` Warning 1] — `set_error()` clears
+`refreshing` and `loading` but leaves `bootable_refreshing` and `bootable_loading` untouched.
+Today this is masked because `spawn_bootable_device_discovery` swallows errors via
+`unwrap_or_default()`, so `set_error()` is never reached from the bootable path. But the
+asymmetry has no comment justifying it; the next maintainer who routes a real bootable error
+into `set_error()` will silently leave the spinner stuck. Either add a comment explaining the
+asymmetry, or make it symmetric.
+
+### 🟡 m4. Compact-mode rendering omits the `↻` indicator
+[Sources: `bug_fix_reviewer` Observation 3, `architecture_enforcer` Recommendation 1] —
+`render_tabs_compact` in `target_selector.rs` doesn't take or use the refreshing flags. Users on
+short terminals get no visual cue that a refresh is in flight. The plan didn't explicitly spell
+this out as in/out of scope, but it's a noticeable gap.
+
+### 🟡 m5. Concurrent close+reopen can prematurely clear the indicator
+[Source: `logic_reasoning_checker` Warning 3] — A discovery in flight when the user closes the
+dialog will, on completion, call `set_connected_devices()` if the dialog is visible again,
+clearing the new dialog's `refreshing` flag before its own discovery has finished. Convergence
+is correct; the visual cue lies. Comment near the flag-set acknowledging the race would help
+future readers.
+
+### 🟡 m6. Stale `TODO: deduplicate with device_list::calculate_scroll_offset` in
+`target_selector_state.rs:455`
+[Source: `code_quality_inspector` MINOR 4] — Pre-existing, but it sits adjacent to new code and
+flags known duplication.
+
+### 🟡 m7. Dead branch in `handle_close_new_session_dialog`
+[Source: `code_quality_inspector` MINOR 5] — Both arms of `if state.session_manager.has_running_sessions()`
+in `navigation.rs` set `state.ui_mode = UiMode::Normal`; the comment says "stay in startup mode"
+but doesn't. Pre-existing, but in modified-file scope.
+
+### 🟡 m8. Indicator visibility on inactive tabs — confirm intent
+[Source: `logic_reasoning_checker` Warning 2] — Implementation (and BUG.md Phase 2 §1) shows
+`↻` on **both** tabs simultaneously when both flags are set, regardless of which is active.
+The orchestration prompt phrased this as "active tab shows ↻". The implementation matches the
+plan, but worth a quick decision: should inactive-tab refreshes be visible, or only active-tab?
+
+---
+
+## Nitpicks
+
+- 🔵 n1. `RefreshDevicesAndBootableBackground { flutter: FlutterExecutable }` is a one-liner;
+  sibling variants in the enum use multi-line form with a `///` doc on the inner field.
+- 🔵 n2. Test assertion in `test_tab_bar_renders_bootable_refreshing_indicator` lacks the
+  diagnostic message its sister test has.
+- 🔵 n3. `cached_devices.clone()` in `navigation.rs` would read more clearly with `len`
+  captured first (style only).
+
+---
+
+## Documentation Freshness Check
+
+- `docs/ARCHITECTURE.md` — no new modules/crates added → no update needed
+- `docs/DEVELOPMENT.md` — no new build steps/deps/commands → no update needed
+- `docs/CODE_STANDARDS.md` — no new error types/macros/conventions → no update needed
+- `docs/REVIEW_FOCUS.md` — `Cell<usize>` exception remains the only render-hint write-back; new
+  `refreshing`/`bootable_refreshing` fields are plain `bool` and write through handlers normally
+  → no update needed
+- `BUG.md` "Cache Becoming Severely Stale" mitigation note (line 191) is **factually
+  incorrect** as currently written — should be updated alongside the fix for finding C1
+
+---
+
+## Architecture & TEA Compliance
+
+✅ All 8 modified files stay within their declared layers (`fdemon-app` and `fdemon-tui`).
+✅ `update()` remains pure; new side effects deferred via `UpdateAction`.
+✅ No new layer-boundary imports.
+✅ The combined-action pattern (`RefreshDevicesAndBootableBackground`) is a reasonable narrow
+   workaround for `UpdateResult` carrying a single action — not a problematic precedent given
+   its narrow scope and rationale.
+
+---
+
+## Test Coverage
+
+| Layer | Added tests | Adequacy |
+|---|---|---|
+| `target_selector_state.rs` | 4 unit tests for refreshing flag clearing | ✅ |
+| `navigation.rs` | 3 new + 2 updated dialog-open tests | ✅ for cache-hit; ⚠️ no test for both-empty branch (M1) |
+| `handler/tests.rs` | 1 integration test for `DevicesDiscovered` clearing flag | ⚠️ asymmetric — no bootable counterpart (m1) |
+| `tab_bar.rs` | 3 render tests (Connected, Bootable, no-glyph) | ✅ |
+| `target_selector.rs` | 3 render tests (mirror of tab_bar tests) | ✅ |
+
+Total: 4,715 unit tests pass workspace-wide, 0 failures, 7 ignored.
+`cargo clippy --workspace --lib -- -D warnings` clean.
+
+---
+
+## Re-review Checklist
+
+- [ ] C1 fixed: `refreshing` is cleared in the `is_background: true` branch (and BUG.md note
+  corrected)
+- [ ] M1 addressed: cache-miss fallback also triggers bootable discovery (or M1 explicitly
+  documented as out of scope)
+- [ ] M2 addressed: `get_cached_bootable_devices()` returns references, or owned-return is
+  documented as deliberate
+- [ ] At least m1, m2, m3 addressed (test symmetry, glyph constant, set_error asymmetry note)
+- [ ] `cargo fmt && cargo check --workspace && cargo test --workspace --lib && cargo clippy
+  --workspace --lib -- -D warnings` passes
+
+See [ACTION_ITEMS.md](ACTION_ITEMS.md) for the prioritized worklist.


### PR DESCRIPTION
 - Replace the 30s device-cache TTL with an indefinite cache + background refresh, so the
   new-session dialog opens instantly from cache.
  - Show a `↻` indicator on the Connected/Bootable tabs (full and compact) while a refresh
   is in flight; clears on every outcome — success, foreground failure, and background
  failure.
  - Cache-miss path now dispatches both connected and bootable discovery in parallel;
  bootable accessor returns refs (no hidden clone).

Closes #33 