### PR TITLE
Pressing "x" when device disconnects returns to device picker instead of closing fdemon entirely

### DIFF
--- a/crates/fdemon-app/src/handler/session.rs
+++ b/crates/fdemon-app/src/handler/session.rs
@@ -118,6 +118,11 @@ pub fn handle_session_exited(state: &mut AppState, session_id: SessionId, code: 
         handle
             .session
             .add_log(LogEntry::new(level, LogSource::App, message));
+        handle.session.add_log(LogEntry::new(
+            LogLevel::Info,
+            LogSource::App,
+            "Press 'x' or Ctrl+W to return to the device picker.".to_string(),
+        ));
         handle.session.phase = AppPhase::Stopped;
         handle.session.vm_connected = false;
 

--- a/crates/fdemon-app/src/handler/session_lifecycle.rs
+++ b/crates/fdemon-app/src/handler/session_lifecycle.rs
@@ -277,13 +277,23 @@ fn close_session_internal(state: &mut AppState, session_id: SessionId) -> Update
 
 /// Handle close current session message
 pub fn handle_close_current_session(state: &mut AppState) -> UpdateResult {
-    // If there's only one session (or none), treat 'x' as quit request
-    if state.session_manager.len() <= 1 {
+    let current_session_id = state.session_manager.selected_id();
+
+    // A Stopped session is a dead tab the user wants to dismiss — never let
+    // `x` on a dead session quit fdemon. Fall through to close_session_internal
+    // so it's removed and (if it was the last) the device picker reappears.
+    let current_is_stopped = current_session_id
+        .and_then(|id| state.session_manager.get(id))
+        .map(|h| h.session.phase == AppPhase::Stopped)
+        .unwrap_or(false);
+
+    // If there's only one (live) session (or none), treat 'x' as quit request
+    if state.session_manager.len() <= 1 && !current_is_stopped {
         state.request_quit();
         return UpdateResult::none();
     }
 
-    let Some(current_session_id) = state.session_manager.selected_id() else {
+    let Some(current_session_id) = current_session_id else {
         return UpdateResult::none();
     };
 

--- a/crates/fdemon-app/src/handler/tests.rs
+++ b/crates/fdemon-app/src/handler/tests.rs
@@ -5098,6 +5098,117 @@ fn test_session_exited_cleans_up_network_monitoring() {
     );
 }
 
+// ─────────────────────────────────────────────────────────
+// Dismiss-on-stopped-session → return to picker (instead of quit fdemon)
+// ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_close_current_session_on_stopped_only_session_returns_to_picker() {
+    let device = test_device("dev-1", "Device 1");
+    let mut state = AppState::new();
+    let session_id = state.session_manager.create_session(&device).unwrap();
+    state.session_manager.select_by_id(session_id);
+
+    // Simulate a dead session: device disconnected / process exited.
+    state
+        .session_manager
+        .get_mut(session_id)
+        .unwrap()
+        .session
+        .phase = AppPhase::Stopped;
+
+    // Action: user presses 'x' on the dead tab.
+    super::session_lifecycle::handle_close_current_session(&mut state);
+
+    assert_ne!(
+        state.phase,
+        AppPhase::Quitting,
+        "closing a Stopped session must not quit fdemon"
+    );
+    assert!(
+        state.session_manager.is_empty(),
+        "the dead session should be removed"
+    );
+    assert_eq!(
+        state.ui_mode,
+        UiMode::NewSessionDialog,
+        "after dismissing the last dead session the device picker should reappear"
+    );
+}
+
+#[test]
+fn test_close_current_session_on_running_only_session_still_quits() {
+    let device = test_device("dev-1", "Device 1");
+    let mut state = AppState::new();
+    let session_id = state.session_manager.create_session(&device).unwrap();
+    state.session_manager.select_by_id(session_id);
+
+    let alive_phase = state.session_manager.get(session_id).unwrap().session.phase;
+    assert_ne!(
+        alive_phase,
+        AppPhase::Stopped,
+        "precondition: a freshly created session must not be Stopped"
+    );
+
+    super::session_lifecycle::handle_close_current_session(&mut state);
+
+    assert_eq!(
+        state.phase,
+        AppPhase::Quitting,
+        "pressing 'x' on the only live session should still quit fdemon"
+    );
+}
+
+#[test]
+fn test_session_exited_appends_picker_hint_log() {
+    let device = test_device("dev-1", "Device 1");
+    let mut state = AppState::new();
+    let session_id = state.session_manager.create_session(&device).unwrap();
+
+    super::session::handle_session_exited(&mut state, session_id, Some(0));
+
+    let handle = state.session_manager.get(session_id).unwrap();
+    let messages: Vec<&str> = handle
+        .session
+        .logs
+        .iter()
+        .map(|e| e.message.as_str())
+        .collect();
+    assert!(
+        messages.iter().any(|m| m.contains("exited")),
+        "expected an 'exited' log line; got: {:?}",
+        messages
+    );
+    assert_eq!(
+        messages.iter().filter(|m| m.contains("Press 'x'")).count(),
+        1,
+        "expected exactly one picker-hint line; got: {:?}",
+        messages
+    );
+}
+
+#[test]
+fn test_duplicate_session_exit_does_not_double_log_hint() {
+    let device = test_device("dev-1", "Device 1");
+    let mut state = AppState::new();
+    let session_id = state.session_manager.create_session(&device).unwrap();
+
+    super::session::handle_session_exited(&mut state, session_id, Some(0));
+    super::session::handle_session_exited(&mut state, session_id, Some(0));
+
+    let handle = state.session_manager.get(session_id).unwrap();
+    let hint_count = handle
+        .session
+        .logs
+        .iter()
+        .filter(|e| e.message.contains("Press 'x'"))
+        .count();
+    assert_eq!(
+        hint_count, 1,
+        "duplicate exit events must not duplicate the picker hint"
+    );
+}
+
 #[test]
 fn test_app_stop_signals_perf_shutdown() {
     use fdemon_core::{AppStart, AppStop, DaemonMessage};

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -78,8 +78,8 @@ Flutter Demon supports running up to 9 simultaneous device sessions.
 | `1`-`9` | Switch Session | Switch to session 1-9 by index |
 | `Tab` | Next Session | Cycle to the next session |
 | `Shift+Tab` | Previous Session | Cycle to the previous session |
-| `x` | Close Session | Close the current session |
-| `Ctrl+W` | Close Session | Alternative binding to close current session |
+| `x` | Close Session | Close the current session. If only one session remains and it's still running, quits fdemon. If only one session remains and it has stopped (device disconnected, process exited), dismisses it and returns to the device picker instead of quitting. |
+| `Ctrl+W` | Close Session | Alternative binding to close current session (same Stopped-session behavior as `x`). |
 | `+` | Start New Session | Start a new session (shows Startup Dialog if no sessions, Device Selector if sessions exist) |
 | `d` | DevTools Mode | Enter DevTools mode (Inspector/Performance/Network panels) |
 | `D` | Toggle DAP Server | Start or stop the DAP debug adapter server |


### PR DESCRIPTION
I found that whenever my device disconnected, I had to close fdemon and restart it. Which was super annoying. So I implemented this fix so that pressing "x" when the device disconnects doesn't close fdemon but instead takes the user to the device picker.

Just a little nice to have :)