### PR TITLE
feat: service-surface expansion + run_with_engine embedder seam

### DIFF
--- a/crates/fdemon-app/src/engine.rs
+++ b/crates/fdemon-app/src/engine.rs
@@ -20,8 +20,8 @@ use crate::handler::UpdateAction;
 use crate::message::Message;
 use crate::process;
 use crate::services::{
-    CommandSenderController, LocalFlutterController, ProjectInfo, SharedLogService, SharedState,
-    SharedStateService,
+    CommandSenderController, FlutterProjectService, LocalFlutterController, ProjectInfo,
+    SessionSnapshot, SharedLogService, SharedSessionService, SharedState, SharedStateService,
 };
 use crate::session::SessionId;
 use crate::signals;
@@ -448,6 +448,53 @@ impl Engine {
                 *logs = session.logs.iter().cloned().collect();
             }
         }
+
+        // Sync snapshots of ALL sessions (not just the selected one) for the
+        // SessionService consumers. Runs even with zero sessions so removals
+        // are reflected.
+        if let Ok(mut sessions) = self.shared_state.sessions.try_write() {
+            *sessions = self
+                .state
+                .session_manager
+                .iter()
+                .map(|handle| {
+                    let session = &handle.session;
+                    SessionSnapshot {
+                        session_id: session.id,
+                        name: session.name.clone(),
+                        device_id: session.device_id.clone(),
+                        device_name: session.device_name.clone(),
+                        platform: session.platform.clone(),
+                        phase: session.phase,
+                        app_id: session.app_id.clone(),
+                        devtools_url: session
+                            .devtools_endpoint
+                            .as_ref()
+                            .zip(session.ws_uri.as_ref())
+                            .map(|(endpoint, ws_uri)| endpoint.url(ws_uri)),
+                    }
+                })
+                .collect();
+        }
+
+        // Sync the device cache so StateService::get_devices works for
+        // service consumers.
+        if let Some(devices) = self.state.get_cached_devices() {
+            if let Ok(mut shared_devices) = self.shared_state.devices.try_write() {
+                *shared_devices = devices
+                    .iter()
+                    .map(|d| fdemon_core::DeviceInfo {
+                        id: d.id.clone(),
+                        name: d.name.clone(),
+                        platform: d.platform.clone(),
+                        emulator: d.emulator,
+                        category: d.category.clone(),
+                        platform_type: d.platform_type.clone(),
+                        ephemeral: d.ephemeral,
+                    })
+                    .collect();
+            }
+        }
     }
 
     /// Get a clone of the message sender for spawning input sources.
@@ -558,6 +605,42 @@ impl Engine {
             cmd_sender.clone(),
             self.shared_state.clone(),
         ))
+    }
+
+    /// Get an owned, `Send + 'static` FlutterController for the currently
+    /// selected session.
+    ///
+    /// Unlike [`Engine::flutter_controller`], the returned controller does not
+    /// borrow the Engine and implements the `Send` trait variant
+    /// ([`crate::services::FlutterController`]), so remote consumers (MCP
+    /// server) can move it into spawned tokio tasks and call
+    /// `reload()`/`restart()` from there.
+    ///
+    /// Returns None if no session is selected or no command sender is available.
+    pub fn flutter_controller_owned(&self) -> Option<CommandSenderController> {
+        let session = self.state.session_manager.selected()?;
+        let cmd_sender = session.cmd_sender.as_ref()?;
+        Some(CommandSenderController::new(
+            cmd_sender.clone(),
+            self.shared_state.clone(),
+        ))
+    }
+
+    /// Get a session control service (list/start/stop sessions, DevTools URLs).
+    ///
+    /// `Send + 'static`: reads come from SharedState snapshots, control
+    /// operations are dispatched through the Engine's message channel.
+    pub fn session_service(&self) -> SharedSessionService {
+        SharedSessionService::new(self.shared_state.clone(), self.msg_tx.clone())
+    }
+
+    /// Get a project operations service (`flutter pub get` / `flutter clean`).
+    ///
+    /// Returns None when no Flutter SDK has been resolved.
+    pub fn project_service(&self) -> Option<FlutterProjectService> {
+        self.state.resolved_sdk.as_ref().map(|sdk| {
+            FlutterProjectService::new(sdk.executable.clone(), self.project_path.clone())
+        })
     }
 
     /// Get access to the shared log service.
@@ -989,6 +1072,151 @@ mod tests {
 
         // No session selected, should return None
         assert!(engine.flutter_controller().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_flutter_controller_owned_none_without_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = Engine::new(dir.path().to_path_buf());
+
+        assert!(engine.flutter_controller_owned().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_flutter_controller_owned_is_send_and_static() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+        let session_id = engine
+            .state
+            .session_manager
+            .create_session(&test_device("dev-1", "Pixel 6"))
+            .unwrap();
+        engine
+            .state
+            .session_manager
+            .get_mut(session_id)
+            .unwrap()
+            .cmd_sender = Some(fdemon_daemon::CommandSender::new_for_test());
+
+        let controller = engine
+            .flutter_controller_owned()
+            .expect("session with cmd_sender should yield a controller");
+
+        // Moving the controller into a spawned task requires Send + 'static.
+        let handle = tokio::spawn(async move {
+            crate::services::FlutterController::is_running(&controller).await
+        });
+        assert!(!handle.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_session_service_accessor() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = Engine::new(dir.path().to_path_buf());
+
+        let _session_service = engine.session_service();
+        // Should not panic
+    }
+
+    #[tokio::test]
+    async fn test_project_service_none_without_sdk() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+        engine.state.resolved_sdk = None;
+
+        assert!(engine.project_service().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_project_service_some_with_resolved_sdk() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+        engine.state.resolved_sdk = Some(fdemon_daemon::test_utils::fake_flutter_sdk());
+
+        assert!(engine.project_service().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_session_snapshots_synced_to_shared_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+        let session_id = engine
+            .state
+            .session_manager
+            .create_session(&test_device("dev-1", "Pixel 6"))
+            .unwrap();
+        {
+            let handle = engine.state.session_manager.get_mut(session_id).unwrap();
+            handle.session.app_id = Some("app-1".to_string());
+            handle.session.ws_uri = Some("ws://127.0.0.1:1234/abc=/ws".to_string());
+            handle.session.devtools_endpoint = Some(crate::session::DevToolsEndpoint {
+                base_url: "http://127.0.0.1:9100".to_string(),
+            });
+        }
+
+        engine.flush_pending_logs();
+
+        let sessions = engine.shared_state().sessions.read().await;
+        assert_eq!(sessions.len(), 1);
+        let snapshot = &sessions[0];
+        assert_eq!(snapshot.session_id, session_id);
+        assert_eq!(snapshot.device_id, "dev-1");
+        assert_eq!(snapshot.device_name, "Pixel 6");
+        assert_eq!(snapshot.app_id, Some("app-1".to_string()));
+        let devtools_url = snapshot.devtools_url.as_deref().unwrap();
+        assert!(devtools_url.starts_with("http://127.0.0.1:9100?uri="));
+    }
+
+    #[tokio::test]
+    async fn test_session_snapshot_devtools_url_none_without_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+        engine
+            .state
+            .session_manager
+            .create_session(&test_device("dev-1", "Pixel 6"))
+            .unwrap();
+
+        engine.flush_pending_logs();
+
+        let sessions = engine.shared_state().sessions.read().await;
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions[0].devtools_url.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_session_snapshots_cleared_after_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+        let session_id = engine
+            .state
+            .session_manager
+            .create_session(&test_device("dev-1", "Pixel 6"))
+            .unwrap();
+        engine.flush_pending_logs();
+        assert_eq!(engine.shared_state().sessions.read().await.len(), 1);
+
+        engine.state.session_manager.remove_session(session_id);
+        engine.flush_pending_logs();
+
+        assert!(engine.shared_state().sessions.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_device_cache_synced_to_shared_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+        engine
+            .state
+            .set_device_cache(vec![test_device("dev-1", "Pixel 6")]);
+
+        engine.flush_pending_logs();
+
+        let devices = engine.shared_state().devices.read().await;
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].id, "dev-1");
+        assert_eq!(devices[0].name, "Pixel 6");
+        assert_eq!(devices[0].platform, "android");
     }
 
     #[tokio::test]

--- a/crates/fdemon-app/src/handler/session_lifecycle.rs
+++ b/crates/fdemon-app/src/handler/session_lifecycle.rs
@@ -347,3 +347,71 @@ pub fn handle_close_session_at(state: &mut AppState, index: usize) -> UpdateResu
 
     close_session_internal(state, session_id)
 }
+
+/// Start a new session on the device with `device_id`.
+///
+/// Service-layer entry point (`services::SessionService`): resolves the
+/// device from the device cache, creates a session, and dispatches
+/// `SpawnSession` — the same machinery the dialog and headless auto-start
+/// use. No-op with a warning when the device id is unknown, no Flutter SDK
+/// is resolved, or the session limit is reached.
+pub fn handle_start_session_on_device(state: &mut AppState, device_id: &str) -> UpdateResult {
+    let Some(device) = state
+        .get_cached_devices()
+        .and_then(|devices| devices.iter().find(|d| d.id == device_id))
+        .cloned()
+    else {
+        tracing::warn!(
+            "StartSessionOnDevice: device '{}' not in device cache — run device discovery first",
+            device_id
+        );
+        return UpdateResult::none();
+    };
+
+    let Some(flutter) = state.flutter_executable() else {
+        tracing::warn!("StartSessionOnDevice: no Flutter SDK resolved — cannot spawn session");
+        return UpdateResult::none();
+    };
+
+    match state.session_manager.create_session(&device) {
+        Ok(session_id) => {
+            state
+                .pending_engine_events
+                .push(crate::engine_event::EngineEvent::SessionCreated {
+                    session_id,
+                    device: device.clone(),
+                });
+            tracing::info!(
+                "StartSessionOnDevice: created session {} on {} ({})",
+                session_id,
+                device.name,
+                device.id
+            );
+            UpdateResult::action(UpdateAction::SpawnSession {
+                session_id,
+                device,
+                config: None,
+                flutter,
+            })
+        }
+        Err(e) => {
+            tracing::warn!("StartSessionOnDevice: failed to create session: {}", e);
+            UpdateResult::none()
+        }
+    }
+}
+
+/// Stop the app and remove the session with `session_id`.
+///
+/// Service-layer entry point (`services::SessionService`). Reuses the same
+/// close path as the keyboard shortcuts, but intentionally without the
+/// "last session = quit" conversion: a remote consumer stopping the only
+/// session must not terminate fdemon.
+pub fn handle_stop_session_by_id(state: &mut AppState, session_id: SessionId) -> UpdateResult {
+    if state.session_manager.get(session_id).is_none() {
+        tracing::warn!("StopSessionById: unknown session id {}", session_id);
+        return UpdateResult::none();
+    }
+
+    close_session_internal(state, session_id)
+}

--- a/crates/fdemon-app/src/handler/tests.rs
+++ b/crates/fdemon-app/src/handler/tests.rs
@@ -659,6 +659,145 @@ fn test_close_session_at_zero_when_selected_is_zero_picks_next() {
 }
 
 // ─────────────────────────────────────────────────────────
+// Service-layer session control tests (SessionService)
+// ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_start_session_on_device_spawns_session_from_cache() {
+    let mut state = AppState::new();
+    state.resolved_sdk = Some(fdemon_daemon::test_utils::fake_flutter_sdk());
+    state.set_device_cache(vec![
+        test_device("emulator-5554", "Pixel 6"),
+        test_device("d2", "iPhone"),
+    ]);
+
+    let result = update(
+        &mut state,
+        Message::StartSessionOnDevice {
+            device_id: "emulator-5554".to_string(),
+        },
+    );
+
+    assert_eq!(state.session_manager.len(), 1);
+    match result.action {
+        Some(UpdateAction::SpawnSession { device, config, .. }) => {
+            assert_eq!(device.id, "emulator-5554");
+            assert!(
+                config.is_none(),
+                "service-layer start uses no launch config"
+            );
+        }
+        other => panic!("expected SpawnSession action, got {:?}", other),
+    }
+    // SessionCreated is queued for the Engine's event broadcast.
+    assert!(state.pending_engine_events.iter().any(|e| matches!(
+        e,
+        crate::engine_event::EngineEvent::SessionCreated { device, .. }
+            if device.id == "emulator-5554"
+    )));
+}
+
+#[test]
+fn test_start_session_on_device_unknown_device_is_noop() {
+    let mut state = AppState::new();
+    state.resolved_sdk = Some(fdemon_daemon::test_utils::fake_flutter_sdk());
+    state.set_device_cache(vec![test_device("d1", "Pixel")]);
+
+    let result = update(
+        &mut state,
+        Message::StartSessionOnDevice {
+            device_id: "no-such-device".to_string(),
+        },
+    );
+
+    assert_eq!(state.session_manager.len(), 0);
+    assert!(result.action.is_none());
+}
+
+#[test]
+fn test_start_session_on_device_without_sdk_is_noop() {
+    let mut state = AppState::new();
+    state.resolved_sdk = None;
+    state.set_device_cache(vec![test_device("d1", "Pixel")]);
+
+    let result = update(
+        &mut state,
+        Message::StartSessionOnDevice {
+            device_id: "d1".to_string(),
+        },
+    );
+
+    assert_eq!(state.session_manager.len(), 0);
+    assert!(result.action.is_none());
+}
+
+#[test]
+fn test_start_session_on_device_empty_cache_is_noop() {
+    let mut state = AppState::new();
+    state.resolved_sdk = Some(fdemon_daemon::test_utils::fake_flutter_sdk());
+
+    let result = update(
+        &mut state,
+        Message::StartSessionOnDevice {
+            device_id: "d1".to_string(),
+        },
+    );
+
+    assert_eq!(state.session_manager.len(), 0);
+    assert!(result.action.is_none());
+}
+
+#[test]
+fn test_stop_session_by_id_removes_only_that_session() {
+    let mut state = AppState::new();
+    let id1 = state
+        .session_manager
+        .create_session(&test_device("d1", "iPhone"))
+        .unwrap();
+    let id2 = state
+        .session_manager
+        .create_session(&test_device("d2", "Pixel"))
+        .unwrap();
+
+    update(&mut state, Message::StopSessionById { session_id: id1 });
+
+    assert_eq!(state.session_manager.len(), 1);
+    assert!(state.session_manager.get(id1).is_none());
+    assert!(state.session_manager.get(id2).is_some());
+}
+
+#[test]
+fn test_stop_session_by_id_unknown_id_is_noop() {
+    let mut state = AppState::new();
+    state
+        .session_manager
+        .create_session(&test_device("d1", "iPhone"))
+        .unwrap();
+
+    update(&mut state, Message::StopSessionById { session_id: 9999 });
+
+    assert_eq!(state.session_manager.len(), 1);
+}
+
+#[test]
+fn test_stop_session_by_id_last_session_does_not_quit() {
+    let mut state = AppState::new();
+    let id = state
+        .session_manager
+        .create_session(&test_device("d1", "iPhone"))
+        .unwrap();
+    state.settings.behavior.confirm_quit = false;
+
+    update(&mut state, Message::StopSessionById { session_id: id });
+
+    assert_eq!(state.session_manager.len(), 0);
+    assert!(
+        !state.should_quit(),
+        "remote stop of the last session must not quit fdemon"
+    );
+}
+
+// ─────────────────────────────────────────────────────────
 // Clear logs tests
 // ─────────────────────────────────────────────────────────
 

--- a/crates/fdemon-app/src/handler/update.rs
+++ b/crates/fdemon-app/src/handler/update.rs
@@ -680,6 +680,18 @@ pub fn update(state: &mut AppState, message: Message) -> UpdateResult {
         }
 
         // ─────────────────────────────────────────────────────────
+        // Service-Layer Session Control (SessionService)
+        // ─────────────────────────────────────────────────────────
+        Message::StartSessionOnDevice { device_id } => {
+            session_lifecycle::handle_start_session_on_device(state, &device_id)
+        }
+
+        Message::StopSessionById { session_id } => {
+            state.last_log_click = None;
+            session_lifecycle::handle_stop_session_by_id(state, session_id)
+        }
+
+        // ─────────────────────────────────────────────────────────
         // Log Control (Task 10)
         // ─────────────────────────────────────────────────────────
         Message::ClearLogs => {

--- a/crates/fdemon-app/src/lib.rs
+++ b/crates/fdemon-app/src/lib.rs
@@ -45,6 +45,8 @@
 //! - [`services::FlutterController`] - Reload/restart/stop
 //! - [`services::LogService`] - Log buffer access
 //! - [`services::StateService`] - App state access
+//! - [`services::SessionService`] - Session listing, start/stop by id, DevTools URLs
+//! - [`services::ProjectService`] - Project operations (`pub get`, `clean`)
 //!
 //! ### Configuration
 //! - [`config::Settings`] - Global settings from `.fdemon/config.toml`

--- a/crates/fdemon-app/src/message.rs
+++ b/crates/fdemon-app/src/message.rs
@@ -242,6 +242,24 @@ pub enum Message {
     CloseSessionAt(usize),
 
     // ─────────────────────────────────────────────────────────
+    // Service-Layer Session Control (SessionService)
+    // ─────────────────────────────────────────────────────────
+    /// Start a new session on the device with the given id.
+    ///
+    /// Dispatched by `services::SessionService` consumers (MCP server).
+    /// The device must be present in the device cache; unknown ids are
+    /// ignored with a warning.
+    StartSessionOnDevice { device_id: String },
+
+    /// Stop the app and remove the session with the given id.
+    ///
+    /// Dispatched by `services::SessionService` consumers (MCP server).
+    /// Unlike [`Message::CloseCurrentSession`], stopping the last remaining
+    /// session does not convert into a quit request. Unknown ids are ignored
+    /// with a warning.
+    StopSessionById { session_id: SessionId },
+
+    // ─────────────────────────────────────────────────────────
     // Log Control (Task 10)
     // ─────────────────────────────────────────────────────────
     /// Clear logs for current session

--- a/crates/fdemon-app/src/services/flutter_controller.rs
+++ b/crates/fdemon-app/src/services/flutter_controller.rs
@@ -154,6 +154,10 @@ impl LocalFlutterController for DaemonFlutterController {
 ///
 /// This implementation sends commands directly to the daemon with request ID
 /// tracking and response matching.
+///
+/// Implements the `Send` variant ([`FlutterController`]) so remote consumers
+/// (MCP server) can drive reload/restart from spawned tokio tasks. The
+/// `trait_variant` blanket impl provides [`LocalFlutterController`] for free.
 pub struct CommandSenderController {
     /// Command sender for daemon communication
     sender: CommandSender,
@@ -167,7 +171,7 @@ impl CommandSenderController {
     }
 }
 
-impl LocalFlutterController for CommandSenderController {
+impl FlutterController for CommandSenderController {
     async fn reload(&self) -> Result<ReloadResult> {
         let app_id = self
             .state
@@ -368,6 +372,57 @@ mod tests {
             controller.get_app_id().await,
             Some("test-app-123".to_string())
         );
+    }
+
+    /// Compile-time proof that `CommandSenderController` satisfies the `Send`
+    /// trait variant (required for use from spawned tokio tasks).
+    fn assert_send_controller<T: FlutterController>(_: &T) {}
+
+    #[tokio::test]
+    async fn test_command_sender_controller_usable_from_spawned_task() {
+        let sender = fdemon_daemon::CommandSender::new_for_test();
+        let state = Arc::new(SharedState::new(100));
+        state.app_state.write().await.app_id = Some("app-42".to_string());
+
+        let controller = CommandSenderController::new(sender, state);
+        assert_send_controller(&controller);
+
+        // Both traits are implemented (Local via the trait_variant blanket
+        // impl), so disambiguate via the Send-variant path explicitly.
+        let handle = tokio::spawn(async move {
+            let app_id = FlutterController::get_app_id(&controller).await;
+            let running = FlutterController::is_running(&controller).await;
+            (app_id, running)
+        });
+
+        let (app_id, running) = handle.await.unwrap();
+        assert_eq!(app_id, Some("app-42".to_string()));
+        assert!(!running, "Initializing phase is not running");
+    }
+
+    #[tokio::test]
+    async fn test_command_sender_controller_reload_requires_app_id() {
+        let sender = fdemon_daemon::CommandSender::new_for_test();
+        let state = Arc::new(SharedState::new(100));
+        let controller = CommandSenderController::new(sender, state);
+
+        // No app_id set -- reload must fail instead of hanging on the daemon.
+        let result = FlutterController::reload(&controller).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_command_sender_controller_local_variant_via_blanket_impl() {
+        let sender = fdemon_daemon::CommandSender::new_for_test();
+        let state = Arc::new(SharedState::new(100));
+        state.app_state.write().await.app_id = Some("app-7".to_string());
+
+        let controller = CommandSenderController::new(sender, state);
+
+        // The blanket impl must keep the Local variant usable (Engine's
+        // `flutter_controller()` returns `impl LocalFlutterController`).
+        let app_id = LocalFlutterController::get_app_id(&controller).await;
+        assert_eq!(app_id, Some("app-7".to_string()));
     }
 
     #[tokio::test]

--- a/crates/fdemon-app/src/services/log_service.rs
+++ b/crates/fdemon-app/src/services/log_service.rs
@@ -5,16 +5,23 @@
 
 use std::sync::Arc;
 
+use chrono::{DateTime, Local};
 use tokio::sync::RwLock;
 
 use fdemon_core::{LogEntry, LogLevel};
 
 /// Filter for querying logs
+///
+/// All criteria are conjunctive: an entry must match every populated field.
+/// `source` is compared case-insensitively against [`fdemon_core::LogSource::prefix`]
+/// (e.g. `"app"`, `"daemon"`, `"flutter"`, or a native tag name).
 #[derive(Debug, Clone, Default)]
 pub struct LogFilter {
     pub level: Option<LogLevel>,
     pub source: Option<String>,
     pub pattern: Option<String>,
+    /// Only include entries with `timestamp >= since`.
+    pub since: Option<DateTime<Local>>,
     pub limit: Option<usize>,
 }
 
@@ -47,9 +54,48 @@ impl LogFilter {
         self
     }
 
+    pub fn with_source(mut self, source: impl Into<String>) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+
+    pub fn with_since(mut self, since: DateTime<Local>) -> Self {
+        self.since = Some(since);
+        self
+    }
+
     pub fn with_limit(mut self, limit: usize) -> Self {
         self.limit = Some(limit);
         self
+    }
+
+    /// Check whether `log` matches every populated criterion.
+    pub fn matches(&self, log: &LogEntry) -> bool {
+        if let Some(level) = &self.level {
+            if &log.level != level {
+                return false;
+            }
+        }
+
+        if let Some(source) = &self.source {
+            if !log.source.prefix().eq_ignore_ascii_case(source) {
+                return false;
+            }
+        }
+
+        if let Some(pattern) = &self.pattern {
+            if !log.message.contains(pattern.as_str()) {
+                return false;
+            }
+        }
+
+        if let Some(since) = &self.since {
+            if log.timestamp < *since {
+                return false;
+            }
+        }
+
+        true
     }
 }
 
@@ -92,23 +138,7 @@ impl LocalLogService for SharedLogService {
 
         let mut result: Vec<LogEntry> = logs
             .iter()
-            .filter(|log| {
-                // Filter by level
-                if let Some(level) = &filter.level {
-                    if &log.level != level {
-                        return false;
-                    }
-                }
-
-                // Filter by pattern
-                if let Some(pattern) = &filter.pattern {
-                    if !log.message.contains(pattern) {
-                        return false;
-                    }
-                }
-
-                true
-            })
+            .filter(|log| filter.matches(log))
             .cloned()
             .collect();
 
@@ -288,6 +318,157 @@ mod tests {
         service.add_log(LogEntry::info(LogSource::App, "2")).await;
 
         assert_eq!(service.log_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn test_source_filter_matches_prefix_case_insensitive() {
+        let service = create_test_service(100);
+
+        service
+            .add_log(LogEntry::info(LogSource::App, "from app"))
+            .await;
+        service
+            .add_log(LogEntry::info(LogSource::Daemon, "from daemon"))
+            .await;
+        service
+            .add_log(LogEntry::info(LogSource::Flutter, "from flutter"))
+            .await;
+
+        let filtered = service
+            .get_logs(Some(LogFilter::new().with_source("DAEMON")))
+            .await;
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].message, "from daemon");
+    }
+
+    #[tokio::test]
+    async fn test_source_filter_matches_native_tag() {
+        let service = create_test_service(100);
+
+        service
+            .add_log(LogEntry::info(
+                LogSource::Native {
+                    tag: "ActivityManager".to_string(),
+                },
+                "native line",
+            ))
+            .await;
+        service
+            .add_log(LogEntry::info(LogSource::App, "app line"))
+            .await;
+
+        let filtered = service
+            .get_logs(Some(LogFilter::new().with_source("ActivityManager")))
+            .await;
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].message, "native line");
+    }
+
+    #[tokio::test]
+    async fn test_since_filter_excludes_older_entries() {
+        let service = create_test_service(100);
+
+        let mut old = LogEntry::info(LogSource::App, "old");
+        old.timestamp = chrono::Local::now() - chrono::Duration::seconds(60);
+        service.add_log(old).await;
+        service.add_log(LogEntry::info(LogSource::App, "new")).await;
+
+        let cutoff = chrono::Local::now() - chrono::Duration::seconds(30);
+        let filtered = service
+            .get_logs(Some(LogFilter::new().with_since(cutoff)))
+            .await;
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].message, "new");
+    }
+
+    #[tokio::test]
+    async fn test_since_filter_is_inclusive_of_boundary() {
+        let service = create_test_service(100);
+
+        let entry = LogEntry::info(LogSource::App, "boundary");
+        let exact = entry.timestamp;
+        service.add_log(entry).await;
+
+        let filtered = service
+            .get_logs(Some(LogFilter::new().with_since(exact)))
+            .await;
+        assert_eq!(filtered.len(), 1, "timestamp == since must match");
+    }
+
+    #[tokio::test]
+    async fn test_combined_level_pattern_since_filter() {
+        let service = create_test_service(100);
+
+        let mut old_error = LogEntry::error(LogSource::App, "apple crash");
+        old_error.timestamp = chrono::Local::now() - chrono::Duration::seconds(120);
+        service.add_log(old_error).await;
+        service
+            .add_log(LogEntry::error(LogSource::App, "apple crash again"))
+            .await;
+        service
+            .add_log(LogEntry::error(LogSource::App, "banana crash"))
+            .await;
+        service
+            .add_log(LogEntry::info(LogSource::App, "apple info"))
+            .await;
+
+        let cutoff = chrono::Local::now() - chrono::Duration::seconds(30);
+        let filtered = service
+            .get_logs(Some(
+                LogFilter::new()
+                    .with_level(LogLevel::Error)
+                    .with_pattern("apple")
+                    .with_since(cutoff),
+            ))
+            .await;
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].message, "apple crash again");
+    }
+
+    #[tokio::test]
+    async fn test_combined_level_and_source_filter() {
+        let service = create_test_service(100);
+
+        service
+            .add_log(LogEntry::error(LogSource::App, "app error"))
+            .await;
+        service
+            .add_log(LogEntry::error(LogSource::Daemon, "daemon error"))
+            .await;
+        service
+            .add_log(LogEntry::info(LogSource::Daemon, "daemon info"))
+            .await;
+
+        let filtered = service
+            .get_logs(Some(
+                LogFilter::new()
+                    .with_level(LogLevel::Error)
+                    .with_source("daemon"),
+            ))
+            .await;
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].message, "daemon error");
+    }
+
+    #[tokio::test]
+    async fn test_limit_applies_after_other_filters() {
+        let service = create_test_service(100);
+
+        for i in 0..5 {
+            service
+                .add_log(LogEntry::error(LogSource::App, format!("error {}", i)))
+                .await;
+            service
+                .add_log(LogEntry::info(LogSource::App, format!("info {}", i)))
+                .await;
+        }
+
+        let filtered = service
+            .get_logs(Some(LogFilter::errors().with_limit(2)))
+            .await;
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0].message, "error 3");
+        assert_eq!(filtered[1].message, "error 4");
     }
 
     #[tokio::test]

--- a/crates/fdemon-app/src/services/mod.rs
+++ b/crates/fdemon-app/src/services/mod.rs
@@ -30,10 +30,14 @@
 //! - [`FlutterController`]: Hot reload/restart operations
 //! - [`LogService`]: Log buffer access and filtering
 //! - [`StateService`]: App state and device queries
+//! - [`SessionService`]: Session listing, start/stop by id, DevTools URLs
+//! - [`ProjectService`]: Project-level operations (`pub get`, `clean`)
 
 pub mod clipboard;
 mod flutter_controller;
 mod log_service;
+mod project_service;
+mod session_service;
 mod state_service;
 
 #[cfg(test)]
@@ -46,6 +50,14 @@ pub use flutter_controller::{
 };
 
 pub use log_service::{LocalLogService, LogFilter, LogService, SharedLogService};
+
+pub use project_service::{
+    CommandOutput, FlutterProjectService, LocalProjectService, ProjectService,
+};
+
+pub use session_service::{
+    LocalSessionService, SessionService, SessionSnapshot, SharedSessionService,
+};
 
 pub use state_service::{
     AppRunState, LocalStateService, ProjectInfo, SharedState, SharedStateService, StateService,

--- a/crates/fdemon-app/src/services/project_service.rs
+++ b/crates/fdemon-app/src/services/project_service.rs
@@ -143,7 +143,12 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn test_nonzero_exit_reported_as_unsuccessful_not_error() {
-        let service = service_with("/bin/false");
+        // `false` lives in /usr/bin on macOS but /bin on Linux.
+        #[cfg(target_os = "macos")]
+        let false_bin = "/usr/bin/false";
+        #[cfg(not(target_os = "macos"))]
+        let false_bin = "/bin/false";
+        let service = service_with(false_bin);
 
         let output = ProjectService::clean(&service).await.unwrap();
         assert!(!output.success);

--- a/crates/fdemon-app/src/services/project_service.rs
+++ b/crates/fdemon-app/src/services/project_service.rs
@@ -1,0 +1,170 @@
+//! Project-level Flutter operations (pub get, clean)
+//!
+//! This module provides the ProjectService trait for one-shot `flutter`
+//! commands that operate on the project directory rather than a running
+//! session. Both headless tooling and future MCP handlers use this trait.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use fdemon_core::prelude::*;
+use fdemon_daemon::FlutterExecutable;
+
+/// Captured output of a completed one-shot flutter command.
+#[derive(Debug, Clone)]
+pub struct CommandOutput {
+    /// Whether the command exited with status 0
+    pub success: bool,
+    /// Exit code, if the process exited normally (None on signal termination)
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Project-level Flutter operations
+///
+/// Both TUI-side consumers and future MCP handlers use this trait.
+#[trait_variant::make(ProjectService: Send)]
+pub trait LocalProjectService {
+    /// Run `flutter pub get` in the project directory.
+    async fn pub_get(&self) -> Result<CommandOutput>;
+
+    /// Run `flutter clean` in the project directory.
+    async fn clean(&self) -> Result<CommandOutput>;
+}
+
+/// Implementation that invokes the resolved Flutter SDK executable.
+///
+/// `Send + 'static`, so it can be moved into spawned tokio tasks.
+pub struct FlutterProjectService {
+    flutter: FlutterExecutable,
+    project_path: PathBuf,
+}
+
+impl FlutterProjectService {
+    pub fn new(flutter: FlutterExecutable, project_path: PathBuf) -> Self {
+        Self {
+            flutter,
+            project_path,
+        }
+    }
+
+    /// Run the flutter executable with `args` in the project directory and
+    /// capture its output. Non-zero exits are reported via
+    /// [`CommandOutput::success`], not as errors; spawn failures are errors.
+    async fn run_flutter(&self, args: &[&str]) -> Result<CommandOutput> {
+        let output = self
+            .flutter
+            .command()
+            .args(args)
+            .current_dir(&self.project_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .output()
+            .await
+            .map_err(|e| {
+                Error::process(format!("failed to run flutter {}: {}", args.join(" "), e))
+            })?;
+
+        Ok(CommandOutput {
+            success: output.status.success(),
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+}
+
+impl ProjectService for FlutterProjectService {
+    async fn pub_get(&self) -> Result<CommandOutput> {
+        self.run_flutter(&["pub", "get"]).await
+    }
+
+    async fn clean(&self) -> Result<CommandOutput> {
+        self.run_flutter(&["clean"]).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Import only the Send-variant trait: `FlutterProjectService` implements
+    // both variants (Local via the trait_variant blanket impl), so importing
+    // both would make plain method-call syntax ambiguous.
+    use super::{CommandOutput, FlutterProjectService, ProjectService};
+    use fdemon_daemon::FlutterExecutable;
+    use std::path::PathBuf;
+
+    fn service_with(executable: &str) -> FlutterProjectService {
+        FlutterProjectService::new(
+            FlutterExecutable::Direct(PathBuf::from(executable)),
+            std::env::temp_dir(),
+        )
+    }
+
+    #[test]
+    fn test_command_output_fields() {
+        let output = CommandOutput {
+            success: true,
+            exit_code: Some(0),
+            stdout: "ok".to_string(),
+            stderr: String::new(),
+        };
+        assert!(output.success);
+        assert_eq!(output.exit_code, Some(0));
+        assert_eq!(output.stdout, "ok");
+        assert!(output.stderr.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_pub_get_invokes_executable_with_pub_get_args() {
+        // `echo` stands in for the flutter binary: it prints its args, which
+        // proves the service passed `pub get` through.
+        let service = service_with("/bin/echo");
+
+        let output = ProjectService::pub_get(&service).await.unwrap();
+        assert!(output.success);
+        assert_eq!(output.exit_code, Some(0));
+        assert_eq!(output.stdout.trim(), "pub get");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_clean_invokes_executable_with_clean_arg() {
+        let service = service_with("/bin/echo");
+
+        let output = ProjectService::clean(&service).await.unwrap();
+        assert!(output.success);
+        assert_eq!(output.stdout.trim(), "clean");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_nonzero_exit_reported_as_unsuccessful_not_error() {
+        let service = service_with("/bin/false");
+
+        let output = ProjectService::clean(&service).await.unwrap();
+        assert!(!output.success);
+        assert_eq!(output.exit_code, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_missing_executable_returns_error() {
+        let service = service_with("/nonexistent/flutter-binary-for-test");
+
+        let result = ProjectService::pub_get(&service).await;
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_project_service_usable_from_spawned_task() {
+        let service = service_with("/bin/echo");
+
+        let handle = tokio::spawn(async move { ProjectService::pub_get(&service).await });
+        let output = handle.await.unwrap().unwrap();
+        assert!(output.success);
+    }
+}

--- a/crates/fdemon-app/src/services/session_service.rs
+++ b/crates/fdemon-app/src/services/session_service.rs
@@ -1,0 +1,230 @@
+//! Session and device control for external consumers
+//!
+//! This module provides the SessionService trait so remote-control consumers
+//! (the future MCP server) can list, start, and stop Flutter sessions without
+//! direct access to the Engine. Reads come from [`SharedState`] snapshots
+//! (synced by the Engine after each TEA cycle); control operations are
+//! dispatched as [`Message`]s through the Engine's message channel, reusing
+//! the same handler machinery as the keyboard user.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use super::state_service::SharedState;
+use crate::message::Message;
+use crate::session::SessionId;
+use fdemon_core::prelude::*;
+use fdemon_core::AppPhase;
+
+/// Point-in-time view of one active session.
+///
+/// Synced from `AppState::session_manager` into [`SharedState::sessions`]
+/// by the Engine after each message-processing cycle.
+#[derive(Debug, Clone)]
+pub struct SessionSnapshot {
+    pub session_id: SessionId,
+    /// Display name (device name or launch-config name)
+    pub name: String,
+    pub device_id: String,
+    pub device_name: String,
+    pub platform: String,
+    pub phase: AppPhase,
+    /// Daemon-assigned app id, once the app has started
+    pub app_id: Option<String>,
+    /// Full browser DevTools URL (`base_url?uri=<ws_uri>`), once the daemon
+    /// has reported both the DevTools endpoint and the VM Service URI
+    pub devtools_url: Option<String>,
+}
+
+/// Session lifecycle control and inspection
+///
+/// Both TUI-side consumers and future MCP handlers use this trait.
+#[trait_variant::make(SessionService: Send)]
+pub trait LocalSessionService {
+    /// List all active sessions (id, device, phase, DevTools URL).
+    async fn list_sessions(&self) -> Vec<SessionSnapshot>;
+
+    /// Start a new session on the device with the given id.
+    ///
+    /// The device must be present in the device cache (populated by device
+    /// discovery). The request is dispatched through the Engine's message
+    /// channel; success means the request was queued, not that the session
+    /// started. Subscribe to `EngineEvent::SessionStarted` for the outcome.
+    async fn start_session(&self, device_id: &str) -> Result<()>;
+
+    /// Stop the app and remove the session with the given id.
+    ///
+    /// Dispatched through the Engine's message channel; unknown ids are
+    /// ignored by the handler with a warning.
+    async fn stop_session(&self, session_id: SessionId) -> Result<()>;
+
+    /// DevTools URL for a running session, if the daemon has reported one.
+    async fn get_devtools_url(&self, session_id: SessionId) -> Option<String>;
+}
+
+/// Implementation backed by [`SharedState`] snapshots and the Engine's
+/// message channel. Cheap to clone-construct and `Send + 'static`, so it can
+/// be moved into spawned tokio tasks.
+pub struct SharedSessionService {
+    state: Arc<SharedState>,
+    msg_tx: mpsc::Sender<Message>,
+}
+
+impl SharedSessionService {
+    pub fn new(state: Arc<SharedState>, msg_tx: mpsc::Sender<Message>) -> Self {
+        Self { state, msg_tx }
+    }
+}
+
+impl SessionService for SharedSessionService {
+    async fn list_sessions(&self) -> Vec<SessionSnapshot> {
+        self.state.sessions.read().await.clone()
+    }
+
+    async fn start_session(&self, device_id: &str) -> Result<()> {
+        self.msg_tx
+            .send(Message::StartSessionOnDevice {
+                device_id: device_id.to_string(),
+            })
+            .await
+            .map_err(|_| Error::channel_send("start session command"))
+    }
+
+    async fn stop_session(&self, session_id: SessionId) -> Result<()> {
+        self.msg_tx
+            .send(Message::StopSessionById { session_id })
+            .await
+            .map_err(|_| Error::channel_send("stop session command"))
+    }
+
+    async fn get_devtools_url(&self, session_id: SessionId) -> Option<String> {
+        self.state
+            .sessions
+            .read()
+            .await
+            .iter()
+            .find(|s| s.session_id == session_id)
+            .and_then(|s| s.devtools_url.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Import only the Send-variant trait: `SharedSessionService` implements
+    // both variants (Local via the trait_variant blanket impl), so importing
+    // both would make plain method-call syntax ambiguous.
+    use super::{SessionService, SessionSnapshot, SharedSessionService};
+    use crate::message::Message;
+    use crate::services::SharedState;
+    use crate::session::SessionId;
+    use fdemon_core::AppPhase;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    fn snapshot(session_id: SessionId, devtools_url: Option<String>) -> SessionSnapshot {
+        SessionSnapshot {
+            session_id,
+            name: "Pixel 6".to_string(),
+            device_id: "emulator-5554".to_string(),
+            device_name: "Pixel 6".to_string(),
+            platform: "android".to_string(),
+            phase: AppPhase::Running,
+            app_id: Some("app-1".to_string()),
+            devtools_url,
+        }
+    }
+
+    fn create_service() -> (
+        SharedSessionService,
+        mpsc::Receiver<Message>,
+        Arc<SharedState>,
+    ) {
+        let state = Arc::new(SharedState::new(100));
+        let (tx, rx) = mpsc::channel(10);
+        let service = SharedSessionService::new(state.clone(), tx);
+        (service, rx, state)
+    }
+
+    #[tokio::test]
+    async fn test_list_sessions_empty_by_default() {
+        let (service, _rx, _state) = create_service();
+        assert!(service.list_sessions().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_sessions_returns_synced_snapshots() {
+        let (service, _rx, state) = create_service();
+        *state.sessions.write().await = vec![snapshot(1, None), snapshot(2, None)];
+
+        let sessions = service.list_sessions().await;
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].session_id, 1);
+        assert_eq!(sessions[0].device_id, "emulator-5554");
+        assert_eq!(sessions[0].phase, AppPhase::Running);
+    }
+
+    #[tokio::test]
+    async fn test_start_session_sends_message() {
+        let (service, mut rx, _state) = create_service();
+
+        service.start_session("emulator-5554").await.unwrap();
+
+        match rx.try_recv().unwrap() {
+            Message::StartSessionOnDevice { device_id } => {
+                assert_eq!(device_id, "emulator-5554");
+            }
+            other => panic!("expected StartSessionOnDevice, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stop_session_sends_message() {
+        let (service, mut rx, _state) = create_service();
+
+        service.stop_session(7).await.unwrap();
+
+        match rx.try_recv().unwrap() {
+            Message::StopSessionById { session_id } => assert_eq!(session_id, 7),
+            other => panic!("expected StopSessionById, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_session_channel_closed_returns_error() {
+        let (service, rx, _state) = create_service();
+        drop(rx);
+
+        assert!(service.start_session("dev-1").await.is_err());
+        assert!(service.stop_session(1).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_devtools_url_for_known_session() {
+        let (service, _rx, state) = create_service();
+        *state.sessions.write().await = vec![
+            snapshot(1, Some("http://127.0.0.1:9100?uri=ws".to_string())),
+            snapshot(2, None),
+        ];
+
+        assert_eq!(
+            service.get_devtools_url(1).await,
+            Some("http://127.0.0.1:9100?uri=ws".to_string())
+        );
+        assert_eq!(service.get_devtools_url(2).await, None);
+        assert_eq!(service.get_devtools_url(99).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_session_service_usable_from_spawned_task() {
+        let (service, mut rx, _state) = create_service();
+
+        let handle = tokio::spawn(async move { service.start_session("dev-1").await });
+        handle.await.unwrap().unwrap();
+
+        assert!(matches!(
+            rx.try_recv().unwrap(),
+            Message::StartSessionOnDevice { .. }
+        ));
+    }
+}

--- a/crates/fdemon-app/src/services/state_service.rs
+++ b/crates/fdemon-app/src/services/state_service.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Duration, Local};
 use tokio::sync::{broadcast, RwLock};
 
+use super::session_service::SessionSnapshot;
 use fdemon_core::{AppPhase, DaemonMessage, DeviceInfo, LogEntry};
 
 /// Application run state with metadata
@@ -78,6 +79,9 @@ pub struct SharedState {
     /// Known devices
     pub devices: Arc<RwLock<Vec<DeviceInfo>>>,
 
+    /// Snapshots of all active sessions (synced from the SessionManager)
+    pub sessions: Arc<RwLock<Vec<SessionSnapshot>>>,
+
     /// Event broadcaster for multiple subscribers
     pub event_tx: broadcast::Sender<DaemonMessage>,
 
@@ -93,6 +97,7 @@ impl SharedState {
             app_state: Arc::new(RwLock::new(AppRunState::new())),
             logs: Arc::new(RwLock::new(Vec::new())),
             devices: Arc::new(RwLock::new(Vec::new())),
+            sessions: Arc::new(RwLock::new(Vec::new())),
             event_tx,
             max_logs,
         }

--- a/crates/fdemon-tui/src/lib.rs
+++ b/crates/fdemon-tui/src/lib.rs
@@ -8,6 +8,7 @@
 //! ## Entry Points
 //!
 //! - [`run_with_project()`] - Main entry point: creates Engine, initializes terminal, runs event loop
+//! - [`run_with_engine()`] - Embedder entry point: runs the event loop on a caller-constructed Engine
 //! - [`select_project()`] - Interactive project selector (when multiple Flutter projects found)
 //!
 //! ## Widgets
@@ -33,5 +34,5 @@ pub mod widgets;
 pub mod test_utils;
 
 // Re-export main entry points
-pub use runner::{run_with_project, run_with_project_and_dap};
+pub use runner::{run_with_engine, run_with_project, run_with_project_and_dap, DapOptions};
 pub use selector::{select_project, SelectionResult};

--- a/crates/fdemon-tui/src/runner.rs
+++ b/crates/fdemon-tui/src/runner.rs
@@ -3,6 +3,7 @@
 //! Contains the core application lifecycle:
 //! - `run_with_project`: Main entry point with Flutter project
 //! - `run_with_project_and_dap`: Like `run_with_project` but with DAP port override and auto-start
+//! - `run_with_engine`: Embedder entry point - runs the TUI on a caller-constructed `Engine`
 //! - `run`: Demo/test entry point without Flutter
 //! - `run_loop`: Main event loop processing terminal and daemon events
 
@@ -20,10 +21,121 @@ use fdemon_core::prelude::*;
 
 use crate::{event, render, startup, terminal};
 
+/// DAP startup options for [`run_with_engine`].
+///
+/// Mirrors the CLI surface of [`run_with_project_and_dap`]:
+/// - `port` carries the `--dap-port` override (forces `dap.enabled = true`).
+/// - `parent_ide` carries the `--dap-config` IDE override (bypasses
+///   environment-based detection).
+///
+/// Passing `Some(DapOptions::default())` (both fields `None`) still evaluates
+/// [`should_auto_start_dap`] from settings, exactly like
+/// `run_with_project_and_dap(path, None, None)`. Passing `None` to
+/// [`run_with_engine`] skips DAP startup entirely, exactly like
+/// [`run_with_project`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DapOptions {
+    /// `--dap-port` CLI override: sets `settings.dap.port` and forces
+    /// `settings.dap.enabled = true`.
+    pub port: Option<u16>,
+    /// `--dap-config` IDE override: stored on `AppState` so IDE config
+    /// generation bypasses environment-based detection.
+    pub parent_ide: Option<fdemon_app::config::ParentIde>,
+}
+
 /// Run the TUI application with a Flutter project
 pub async fn run_with_project(project_path: &Path) -> Result<()> {
     // Create the engine (handles all shared initialization)
-    let mut engine = Engine::new(project_path.to_path_buf());
+    let engine = Engine::new(project_path.to_path_buf());
+
+    // No DAP options: skip DAP startup entirely (legacy non-DAP entry point).
+    run_with_engine(engine, None).await
+}
+
+/// Run the TUI application with a Flutter project and optional DAP configuration.
+///
+/// This is identical to [`run_with_project`] but also:
+/// 1. Applies a `--dap-port` CLI override to `settings.dap.port` and forces
+///    `settings.dap.enabled = true` when `dap_port` is `Some(port)`.
+/// 2. Applies a `--dap-config` IDE override to `AppState.cli_dap_config_override`
+///    when `dap_config` is `Some(ide)`, bypassing environment-based detection.
+/// 3. Evaluates [`should_auto_start_dap`] after CLI flag processing and sends
+///    `Message::StartDapServer` if the result is `true`.
+///
+/// This covers all startup paths:
+/// - `--dap-port` CLI flag → `dap.enabled = true` → auto-starts
+/// - `dap.enabled = true` in config → auto-starts
+/// - `dap.auto_start_in_ide = true` + IDE detected → auto-starts
+/// - No DAP config + no IDE → does not auto-start
+pub async fn run_with_project_and_dap(
+    project_path: &Path,
+    dap_port: Option<u16>,
+    dap_config: Option<fdemon_app::config::ParentIde>,
+) -> Result<()> {
+    // Create the engine (handles all shared initialization)
+    let engine = Engine::new(project_path.to_path_buf());
+
+    run_with_engine(
+        engine,
+        Some(DapOptions {
+            port: dap_port,
+            parent_ide: dap_config,
+        }),
+    )
+    .await
+}
+
+/// Run the TUI event loop on a caller-constructed [`Engine`].
+///
+/// This is the embedder entry point: a host binary that needs to share one
+/// `Engine` between the TUI and other in-process consumers (e.g. an MCP
+/// server) constructs the `Engine` itself, attaches subscribers, services, or
+/// plugins, and then hands it here. [`run_with_project`] and
+/// [`run_with_project_and_dap`] both delegate to this function.
+///
+/// # Pre-call contract
+///
+/// The engine MUST come from [`Engine::new`], which performs all shared
+/// initialization the TUI relies on: `.fdemon` directory init, settings load,
+/// Flutter SDK resolution, signal handler spawn, and file-watcher start.
+/// Between `Engine::new` and this call, embedders may:
+/// - subscribe to engine events via [`Engine::subscribe`],
+/// - take service handles (`log_service`, `state_service`, ...),
+/// - register plugins via [`Engine::register_plugin`] — this function calls
+///   [`Engine::notify_plugins_start`] before entering the event loop.
+///
+/// Embedders must NOT pre-initialize the terminal or process messages that
+/// return follow-up `Message`s (the channel is drained only once the loop
+/// starts).
+///
+/// # DAP startup
+///
+/// - `dap: None` — skip DAP startup entirely (matches [`run_with_project`]).
+/// - `dap: Some(opts)` — apply the CLI overrides in `opts`, then evaluate
+///   [`should_auto_start_dap`] and send `Message::StartDapServer` if it
+///   returns `true` (matches [`run_with_project_and_dap`]).
+///
+/// # Lifecycle
+///
+/// Takes ownership of the engine and consumes it: on exit (quit or error) the
+/// terminal is restored and [`Engine::shutdown`] is awaited (stops the
+/// watcher, cleans up sessions).
+pub async fn run_with_engine(mut engine: Engine, dap: Option<DapOptions>) -> Result<()> {
+    if let Some(dap) = dap {
+        apply_dap_overrides(&mut engine, dap);
+
+        // Evaluate DAP auto-start (covers config-enabled and IDE-detected scenarios).
+        // --dap-port already sets dap.enabled=true above, so this handles all paths.
+        //
+        // ORDERING: process_message is called synchronously before run_loop starts.
+        // This is safe because StartDapServer returns an UpdateAction (async side
+        // effect), not a follow-up Message. If the handler is changed to return a
+        // follow-up Message, this call site must switch to
+        // engine.msg_sender().try_send() to preserve ordering.
+        if should_auto_start_dap(&engine.settings) {
+            engine.process_message(Message::StartDapServer);
+        }
+    }
 
     // Initialize clipboard: backend chosen from config + environment (OS
     // clipboard on desktop, OSC 52 over SSH/headless). Pushes a warning toast
@@ -70,118 +182,11 @@ pub async fn run_with_project(project_path: &Path) -> Result<()> {
     // Dispatch based on auto-start detection
     dispatch_startup_action(&mut engine, startup_result);
 
-    // Run the main loop
-    let result = run_loop(&mut term, &mut engine, &mut *clipboard);
-
-    // Disable mouse capture FIRST: stops the terminal from generating new
-    // SGR mouse reports before we drain the TTY queue.
-    terminal::disable_mouse_capture();
-
-    // Drain any mouse SGR reports that were already buffered in the kernel
-    // TTY queue before DisableMouseCapture took effect. Without this drain,
-    // those bytes remain in the queue and the shell reads them after exit,
-    // printing garbage on the command line.
-    event::drain_input(std::time::Duration::from_millis(50));
-
-    // Shutdown engine (stops watcher, cleans up sessions). Safe to call now —
-    // no new SGR sequences will queue because capture is already disabled.
-    engine.shutdown().await;
-
-    // Restore terminal (TUI-specific)
-    ratatui::restore();
-
-    result
-}
-
-/// Run the TUI application with a Flutter project and optional DAP configuration.
-///
-/// This is identical to [`run_with_project`] but also:
-/// 1. Applies a `--dap-port` CLI override to `settings.dap.port` and forces
-///    `settings.dap.enabled = true` when `dap_port` is `Some(port)`.
-/// 2. Applies a `--dap-config` IDE override to `AppState.cli_dap_config_override`
-///    when `dap_config` is `Some(ide)`, bypassing environment-based detection.
-/// 3. Evaluates [`should_auto_start_dap`] after CLI flag processing and sends
-///    `Message::StartDapServer` if the result is `true`.
-///
-/// This covers all startup paths:
-/// - `--dap-port` CLI flag → `dap.enabled = true` → auto-starts
-/// - `dap.enabled = true` in config → auto-starts
-/// - `dap.auto_start_in_ide = true` + IDE detected → auto-starts
-/// - No DAP config + no IDE → does not auto-start
-pub async fn run_with_project_and_dap(
-    project_path: &Path,
-    dap_port: Option<u16>,
-    dap_config: Option<fdemon_app::config::ParentIde>,
-) -> Result<()> {
-    // Create the engine (handles all shared initialization)
-    let mut engine = Engine::new(project_path.to_path_buf());
-
-    // Apply --dap-port CLI override: sets port and forces enabled = true in
-    // both settings copies, keeping them in sync.
-    if let Some(port) = dap_port {
-        engine.apply_cli_dap_override(port);
-    }
-
-    // Apply --dap-config IDE override: stored on AppState so handle_started()
-    // can pass it to GenerateIdeConfig, bypassing environment-based detection.
-    if let Some(ide) = dap_config {
-        engine.apply_cli_dap_config_override(ide);
-    }
-
-    // Evaluate DAP auto-start (covers config-enabled and IDE-detected scenarios).
-    // --dap-port already sets dap.enabled=true above, so this handles all paths.
-    //
-    // ORDERING: process_message is called synchronously before run_loop starts.
-    // This is safe because StartDapServer returns an UpdateAction (async side
-    // effect), not a follow-up Message. If the handler is changed to return a
-    // follow-up Message, this call site must switch to
-    // engine.msg_sender().try_send() to preserve ordering.
-    if should_auto_start_dap(&engine.settings) {
-        engine.process_message(Message::StartDapServer);
-    }
-
-    // Initialize clipboard (same backend selection as run_with_project).
-    let mut clipboard = init_clipboard(&mut engine);
-
-    // Initialize terminal (TUI-specific)
-    let mut term = ratatui::init();
-
-    // Install panic hook AFTER ratatui::init() so fdemon's hook wraps
-    // ratatui's. Both use the "take + wrap" set_hook pattern; whichever
-    // installs last wraps the other. Hooks fire LIFO on panic, so this
-    // order guarantees: disable_mouse_capture → ratatui::restore.
-    terminal::install_panic_hook();
-
-    // Enable mouse capture if the user has it on (default true). Failures are
-    // logged and ignored so the rest of the TUI still works.
-    if engine.settings.ui.enable_mouse {
-        if let Err(e) = terminal::enable_mouse_capture() {
-            warn!("mouse capture disabled: {e}");
-        }
-    }
-
-    // TUI-specific startup: detect auto-start or show NewSessionDialog
-    let startup_result =
-        startup::startup_flutter(&mut engine.state, &engine.settings, &engine.project_path);
-
-    // Render first frame
-    if let Err(e) = term.draw(|frame| render::view(frame, &mut engine.state)) {
-        error!("Failed to render initial frame: {}", e);
-    }
-
-    // Trigger startup discovery (non-blocking)
-    spawn::spawn_tool_availability_check(engine.msg_sender());
-    if engine.settings.behavior.should_run_version_check() {
-        spawn::spawn_version_check(
-            engine.msg_sender(),
-            std::time::Duration::from_secs(
-                engine.settings.behavior.version_check_timeout_secs as u64,
-            ),
-        );
-    }
-
-    // Dispatch based on auto-start detection
-    dispatch_startup_action(&mut engine, startup_result);
+    // Notify plugins the engine is about to enter the event loop. No-op when
+    // no plugins are registered (the `run_with_project*` paths); embedders
+    // that registered plugins before calling get the documented on_start
+    // lifecycle callback here.
+    engine.notify_plugins_start();
 
     // Run the main loop
     let result = run_loop(&mut term, &mut engine, &mut *clipboard);
@@ -233,6 +238,25 @@ pub async fn run() -> Result<()> {
     // Restore terminal
     ratatui::restore();
     result
+}
+
+/// Apply the CLI-style DAP overrides carried by [`DapOptions`] to the engine.
+///
+/// Split from [`run_with_engine`] so the override plumbing is unit-testable
+/// without entering the terminal event loop. Does NOT evaluate
+/// [`should_auto_start_dap`] — the caller decides whether auto-start fires.
+fn apply_dap_overrides(engine: &mut Engine, dap: DapOptions) {
+    // Apply --dap-port CLI override: sets port and forces enabled = true in
+    // both settings copies, keeping them in sync.
+    if let Some(port) = dap.port {
+        engine.apply_cli_dap_override(port);
+    }
+
+    // Apply --dap-config IDE override: stored on AppState so handle_started()
+    // can pass it to GenerateIdeConfig, bypassing environment-based detection.
+    if let Some(ide) = dap.parent_ide {
+        engine.apply_cli_dap_config_override(ide);
+    }
 }
 
 /// Select and construct the clipboard backend for this session.
@@ -747,6 +771,76 @@ mod tests {
             "toast must mention 'Clipboard write failed', got: {}",
             toast.text
         );
+    }
+
+    // ─── apply_dap_overrides — run_with_engine DAP plumbing ──────────────────
+
+    /// `DapOptions { port: Some(_) }` must set the DAP port and force
+    /// `enabled = true` in BOTH settings copies (engine cache and AppState),
+    /// matching the historical `--dap-port` handling in
+    /// `run_with_project_and_dap`.
+    #[tokio::test]
+    async fn test_apply_dap_overrides_port_sets_enabled_in_both_settings() {
+        let mut engine = dummy_engine();
+        assert!(
+            !engine.settings.dap.enabled,
+            "test precondition: DAP must be disabled by default"
+        );
+
+        super::apply_dap_overrides(
+            &mut engine,
+            super::DapOptions {
+                port: Some(4711),
+                parent_ide: None,
+            },
+        );
+
+        assert_eq!(engine.settings.dap.port, 4711);
+        assert!(engine.settings.dap.enabled);
+        assert_eq!(engine.state.settings.dap.port, 4711);
+        assert!(engine.state.settings.dap.enabled);
+    }
+
+    /// `DapOptions { parent_ide: Some(_) }` must store the IDE override on
+    /// `AppState.cli_dap_config_override`, matching the historical
+    /// `--dap-config` handling in `run_with_project_and_dap`.
+    #[tokio::test]
+    async fn test_apply_dap_overrides_parent_ide_stored_on_state() {
+        use fdemon_app::config::ParentIde;
+
+        let mut engine = dummy_engine();
+        assert_eq!(engine.state.cli_dap_config_override, None);
+
+        super::apply_dap_overrides(
+            &mut engine,
+            super::DapOptions {
+                port: None,
+                parent_ide: Some(ParentIde::Zed),
+            },
+        );
+
+        assert_eq!(engine.state.cli_dap_config_override, Some(ParentIde::Zed));
+        assert!(
+            !engine.settings.dap.enabled,
+            "parent_ide alone must not force dap.enabled"
+        );
+    }
+
+    /// `DapOptions::default()` (both fields `None`) must leave the engine's
+    /// DAP settings and state untouched — equivalent to
+    /// `run_with_project_and_dap(path, None, None)` before the auto-start
+    /// evaluation.
+    #[tokio::test]
+    async fn test_apply_dap_overrides_default_is_noop() {
+        let mut engine = dummy_engine();
+        let port_before = engine.settings.dap.port;
+        let enabled_before = engine.settings.dap.enabled;
+
+        super::apply_dap_overrides(&mut engine, super::DapOptions::default());
+
+        assert_eq!(engine.settings.dap.port, port_before);
+        assert_eq!(engine.settings.dap.enabled, enabled_before);
+        assert_eq!(engine.state.cli_dap_config_override, None);
     }
 
     // ─── dispatch_startup_action — no-SDK wizard hook ────────────────────────


### PR DESCRIPTION
Two commits enabling out-of-process-style remote control (MCP server in the pro repo) without touching the TUI's behavior.

**feat(app): expand service surface for remote-control consumers**
- `LogFilter` fully implemented (level / source / pattern / inclusive `since` / limit-last)
- `CommandSenderController` now implements the **Send** `FlutterController` variant (Local preserved via the trait_variant blanket impl); new `Engine::flutter_controller_owned()` for spawned tasks
- New `SessionService`: `SessionSnapshot` (incl. `devtools_url`) synced for **all** sessions each cycle; `list_sessions` / `start_session(device_id)` / `stop_session(id)` via additive `Message::StartSessionOnDevice` / `StopSessionById` (stop-by-id never quits the app); `SharedState.devices` now actually populated
- New `ProjectService`: `flutter pub get` / `clean` via the resolved SDK, structured `CommandOutput`
- ~25 new unit tests

**feat(tui): add run_with_engine seam for embedders**
- `runner::run_with_engine(engine, dap)` runs the full TUI lifecycle on a caller-constructed `Engine`; `run_with_project*` delegate with identical setup order (legacy DAP split preserved via `Option<DapOptions>`)
- Shared path now calls `notify_plugins_start()` before `run_loop` — no-op for legacy callers, the documented `on_start` hook for embedders (who must not call it themselves)

Full workspace suite green (3,195+ tests), clippy `-D warnings` and fmt clean. Note for review: with both controller traits in scope the concrete type implements both — import only one or use UFCS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)