### PR TITLE
test(daemon): de-flake custom log readiness test on slow runners

### DIFF
--- a/crates/fdemon-daemon/src/native_logs/custom.rs
+++ b/crates/fdemon-daemon/src/native_logs/custom.rs
@@ -727,8 +727,14 @@ mod tests {
 
         let mut event_rx = handle.event_rx;
         let mut events = Vec::new();
-        while let Ok(Some(event)) = timeout(Duration::from_millis(500), event_rx.recv()).await {
+        // The first event needs a generous timeout: cold Windows CI runners can
+        // take seconds to spawn the child process. Subsequent lines arrive from
+        // the same already-running process, so a short timeout drains the rest.
+        if let Ok(Some(event)) = timeout(Duration::from_secs(10), event_rx.recv()).await {
             events.push(event);
+            while let Ok(Some(event)) = timeout(Duration::from_millis(500), event_rx.recv()).await {
+                events.push(event);
+            }
         }
 
         // Both lines should appear as log events (pattern matching doesn't consume lines).


### PR DESCRIPTION
The 500ms-per-read loop in `test_stdout_ready_logs_still_flow_after_match` missed the first event when cold Windows CI runners took seconds to spawn the child process (flaked on PR #61's first run, passed untouched on rerun). The first read now gets a 10s timeout; subsequent lines come from the already-running process and keep the short 500ms drain timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)