### PR TITLE
feat: DevTools service surface + generic embedder status badge

### DIFF
--- a/crates/fdemon-app/src/engine.rs
+++ b/crates/fdemon-app/src/engine.rs
@@ -20,8 +20,11 @@ use crate::handler::UpdateAction;
 use crate::message::Message;
 use crate::process;
 use crate::services::{
-    CommandSenderController, FlutterProjectService, LocalFlutterController, ProjectInfo,
-    SessionSnapshot, SharedLogService, SharedSessionService, SharedState, SharedStateService,
+    CommandSenderController, DevToolsSessionSnapshot, FlutterProjectService,
+    LocalFlutterController, ProjectInfo, SessionSnapshot, SharedDevToolsService, SharedLogService,
+    SharedSessionService, SharedState, SharedStateService, WidgetTreeSnapshot,
+    DEVTOOLS_SNAPSHOT_MAX_FRAMES, DEVTOOLS_SNAPSHOT_MAX_MEMORY_SAMPLES,
+    DEVTOOLS_SNAPSHOT_MAX_NETWORK_ENTRIES,
 };
 use crate::session::SessionId;
 use crate::signals;
@@ -477,6 +480,89 @@ impl Engine {
                 .collect();
         }
 
+        // Sync per-session DevTools telemetry snapshots for the
+        // DevToolsService consumers. Telemetry vectors are tail-capped by the
+        // DEVTOOLS_SNAPSHOT_MAX_* constants to bound the per-cycle clone cost.
+        if let Ok(mut devtools) = self.shared_state.devtools.try_write() {
+            *devtools = self
+                .state
+                .session_manager
+                .iter()
+                .map(|handle| {
+                    let session = &handle.session;
+                    let frames = &session.performance.frame_history;
+                    let samples = &session.memory.memory_samples;
+                    let requests = &session.network.entries;
+                    DevToolsSessionSnapshot {
+                        session_id: session.id,
+                        vm_connected: session.vm_connected,
+                        perf_monitoring_active: session.performance.monitoring_active,
+                        network_monitoring_active: handle.network_shutdown_tx.is_some(),
+                        network_extensions_available: session.network.extensions_available,
+                        stats: session.performance.stats.clone(),
+                        recent_frames: frames
+                            .iter()
+                            .skip(frames.len().saturating_sub(DEVTOOLS_SNAPSHOT_MAX_FRAMES))
+                            .cloned()
+                            .collect(),
+                        memory_samples: samples
+                            .iter()
+                            .skip(
+                                samples
+                                    .len()
+                                    .saturating_sub(DEVTOOLS_SNAPSHOT_MAX_MEMORY_SAMPLES),
+                            )
+                            .cloned()
+                            .collect(),
+                        network_requests: requests
+                            .iter()
+                            .skip(
+                                requests
+                                    .len()
+                                    .saturating_sub(DEVTOOLS_SNAPSHOT_MAX_NETWORK_ENTRIES),
+                            )
+                            .cloned()
+                            .collect(),
+                    }
+                })
+                .collect();
+        }
+
+        // Sync the cached widget tree for the selected session. The tree can
+        // be large, so it is deep-cloned into an Arc only when the inspector
+        // fetch state changed (fetch started/completed or session switched);
+        // in the steady state this is a cheap field comparison.
+        if let Ok(mut slot) = self.shared_state.widget_tree.try_write() {
+            match self.state.session_manager.selected() {
+                Some(handle) => {
+                    let inspector = &self.state.devtools_view_state.inspector;
+                    let session_id = handle.session.id;
+                    let changed = match slot.as_ref() {
+                        Some(s) => {
+                            s.session_id != session_id
+                                || s.fetched_at != inspector.last_fetch_time
+                                || s.loading != inspector.loading
+                        }
+                        None => true,
+                    };
+                    if changed {
+                        *slot = Some(WidgetTreeSnapshot {
+                            session_id,
+                            fetched_at: inspector.last_fetch_time,
+                            loading: inspector.loading,
+                            error: inspector.error.as_ref().map(|e| e.message.clone()),
+                            root: inspector.root.as_ref().map(|r| Arc::new(r.clone())),
+                        });
+                    }
+                }
+                None => {
+                    if slot.is_some() {
+                        *slot = None;
+                    }
+                }
+            }
+        }
+
         // Sync the device cache so StateService::get_devices works for
         // service consumers.
         if let Some(devices) = self.state.get_cached_devices() {
@@ -632,6 +718,15 @@ impl Engine {
     /// operations are dispatched through the Engine's message channel.
     pub fn session_service(&self) -> SharedSessionService {
         SharedSessionService::new(self.shared_state.clone(), self.msg_tx.clone())
+    }
+
+    /// Get a DevTools telemetry service (frames, memory, network, widget tree,
+    /// headless monitoring control).
+    ///
+    /// `Send + 'static`: reads come from SharedState snapshots, control
+    /// operations are dispatched through the Engine's message channel.
+    pub fn devtools_service(&self) -> SharedDevToolsService {
+        SharedDevToolsService::new(self.shared_state.clone(), self.msg_tx.clone())
     }
 
     /// Get a project operations service (`flutter pub get` / `flutter clean`).
@@ -1823,5 +1918,121 @@ mod tests {
         assert_eq!(config.paths, vec![PathBuf::from("lib")]);
         assert_eq!(config.extensions, vec!["dart".to_string()]);
         assert!(config.auto_reload);
+    }
+
+    // ── DevTools telemetry sync (DevToolsService) ─────────────────────────────
+
+    fn devtools_test_device() -> fdemon_daemon::Device {
+        fdemon_daemon::Device {
+            id: "emulator-5554".to_string(),
+            name: "Pixel 6".to_string(),
+            platform: "android".to_string(),
+            emulator: true,
+            category: None,
+            platform_type: None,
+            ephemeral: false,
+            emulator_id: None,
+            is_supported: true,
+            capabilities: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sync_populates_devtools_snapshots() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+
+        let session_id = engine
+            .state
+            .session_manager
+            .create_session(&devtools_test_device())
+            .unwrap();
+        {
+            let handle = engine.state.session_manager.get_mut(session_id).unwrap();
+            handle.session.vm_connected = true;
+            handle.session.performance.monitoring_active = true;
+            for i in 1..=5u64 {
+                handle.session.performance.frame_history.push(
+                    fdemon_core::performance::FrameTiming {
+                        number: i,
+                        build_micros: 5_000,
+                        raster_micros: 5_000,
+                        elapsed_micros: 10_000,
+                        timestamp: chrono::Local::now(),
+                        phases: None,
+                        shader_compilation: false,
+                    },
+                );
+            }
+        }
+
+        // flush_pending_logs runs the non-blocking SharedState sync.
+        engine.flush_pending_logs();
+
+        let snapshots = engine.shared_state().devtools.read().await.clone();
+        assert_eq!(snapshots.len(), 1);
+        let snap = &snapshots[0];
+        assert_eq!(snap.session_id, session_id);
+        assert!(snap.vm_connected);
+        assert!(snap.perf_monitoring_active);
+        assert!(!snap.network_monitoring_active);
+        assert_eq!(snap.recent_frames.len(), 5);
+        assert_eq!(snap.recent_frames[0].number, 1);
+        assert!(snap.memory_samples.is_empty());
+        assert!(snap.network_requests.is_empty());
+
+        // The service accessor reads the same data.
+        use crate::services::DevToolsService;
+        let service = engine.devtools_service();
+        let perf = service.performance_frames(session_id).await.unwrap();
+        assert_eq!(perf.frames.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_sync_widget_tree_only_clones_on_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+
+        let session_id = engine
+            .state
+            .session_manager
+            .create_session(&devtools_test_device())
+            .unwrap();
+
+        // Simulate a completed inspector fetch for the selected session.
+        engine.state.devtools_view_state.inspector.root = Some(fdemon_core::DiagnosticsNode {
+            description: "RootWidget".to_string(),
+            ..Default::default()
+        });
+        engine.state.devtools_view_state.inspector.loading = false;
+        engine.state.devtools_view_state.inspector.last_fetch_time =
+            Some(std::time::Instant::now());
+
+        engine.flush_pending_logs();
+
+        let slot = engine.shared_state().widget_tree.read().await.clone();
+        let snap = slot.expect("widget tree must be synced for the selected session");
+        assert_eq!(snap.session_id, session_id);
+        let first_root = snap.root.clone().expect("root must be present");
+        assert_eq!(first_root.description, "RootWidget");
+
+        // A second sync with unchanged fetch state must reuse the same Arc
+        // (no deep clone in the steady state).
+        engine.flush_pending_logs();
+        let slot2 = engine.shared_state().widget_tree.read().await.clone();
+        let second_root = slot2.unwrap().root.unwrap();
+        assert!(
+            std::sync::Arc::ptr_eq(&first_root, &second_root),
+            "unchanged inspector state must not re-clone the tree"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_widget_tree_cleared_without_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new(dir.path().to_path_buf());
+
+        engine.flush_pending_logs();
+        assert!(engine.shared_state().widget_tree.read().await.is_none());
     }
 }

--- a/crates/fdemon-app/src/handler/devtools/mod.rs
+++ b/crates/fdemon-app/src/handler/devtools/mod.rs
@@ -6,12 +6,14 @@
 //!
 //! Sub-modules:
 //! - `inspector`: Widget tree fetch handlers, inspector navigation, and layout data handlers
+//! - `monitoring`: Service-level start/stop monitoring handlers (headless embedders)
 //! - `performance`: Frame selection, memory sample, and allocation profile handlers
 //! - `scroll_helpers`: Shared chart-scroll helpers used by `performance` and `memory`
 
 pub(crate) mod debug;
 pub mod inspector;
 pub(crate) mod memory;
+pub(crate) mod monitoring;
 pub(crate) mod network;
 pub(crate) mod performance;
 pub(crate) mod scroll_helpers;
@@ -364,9 +366,13 @@ pub fn handle_devtools_escape(state: &mut AppState) -> UpdateResult {
 pub fn handle_exit_devtools_mode(state: &mut AppState) -> UpdateResult {
     // Pause the entire performance polling loop (memory + alloc).
     // This eliminates all getMemoryUsage/getIsolate RPCs while viewing logs.
+    // Skipped while a service-layer consumer (`StartDevToolsMonitoring`) needs
+    // the memory samples to keep flowing.
     if let Some(handle) = state.session_manager.selected() {
-        if let Some(ref tx) = handle.perf_pause_tx {
-            let _ = tx.send(true); // pause
+        if !handle.devtools_service_monitoring {
+            if let Some(ref tx) = handle.perf_pause_tx {
+                let _ = tx.send(true); // pause
+            }
         }
     }
 
@@ -380,9 +386,12 @@ pub fn handle_exit_devtools_mode(state: &mut AppState) -> UpdateResult {
 
     // Pause network monitoring (if running): the user is leaving DevTools, so
     // no getHttpProfile RPCs should fire while they are viewing logs.
+    // Skipped while a service-layer consumer needs HTTP profile entries.
     if let Some(handle) = state.session_manager.selected() {
-        if let Some(ref tx) = handle.network_pause_tx {
-            let _ = tx.send(true); // pause
+        if !handle.devtools_service_monitoring {
+            if let Some(ref tx) = handle.network_pause_tx {
+                let _ = tx.send(true); // pause
+            }
         }
     }
 
@@ -486,10 +495,13 @@ pub fn handle_switch_panel(state: &mut AppState, panel: DevToolsPanel) -> Update
 
     // Before switching, check if we are leaving the Network panel — if so,
     // pause network polling so no getHttpProfile RPCs fire while on other panels.
+    // Skipped while a service-layer consumer needs HTTP profile entries.
     if old_panel == DevToolsPanel::Network && panel != DevToolsPanel::Network {
         if let Some(handle) = state.session_manager.selected() {
-            if let Some(ref tx) = handle.network_pause_tx {
-                let _ = tx.send(true); // pause network polling
+            if !handle.devtools_service_monitoring {
+                if let Some(ref tx) = handle.network_pause_tx {
+                    let _ = tx.send(true); // pause network polling
+                }
             }
         }
     }
@@ -1472,6 +1484,66 @@ mod tests {
         assert!(
             *perf_rx.borrow(),
             "exiting DevTools should pause performance monitoring (send true on perf_pause_tx)"
+        );
+    }
+
+    #[test]
+    fn test_exit_devtools_keeps_perf_running_when_service_monitoring() {
+        // While a service-layer consumer holds devtools_service_monitoring,
+        // exiting DevTools must NOT pause the performance polling loop.
+        let (mut state, perf_rx, _alloc_rx) = make_state_with_perf_pause();
+        {
+            let handle = state.session_manager.selected_mut().unwrap();
+            handle.devtools_service_monitoring = true;
+            handle.perf_pause_tx.as_ref().unwrap().send(false).unwrap();
+        }
+        assert!(!*perf_rx.borrow(), "precondition: perf should be unpaused");
+
+        handle_exit_devtools_mode(&mut state);
+
+        assert!(
+            !*perf_rx.borrow(),
+            "exit must not pause perf polling while service monitoring is active"
+        );
+    }
+
+    #[test]
+    fn test_exit_devtools_keeps_network_running_when_service_monitoring() {
+        // Same guard for the network polling loop.
+        let mut state = make_state_with_session();
+        let (net_tx, net_rx) = tokio::sync::watch::channel(false);
+        {
+            let handle = state.session_manager.selected_mut().unwrap();
+            handle.devtools_service_monitoring = true;
+            handle.network_pause_tx = Some(std::sync::Arc::new(net_tx));
+        }
+
+        handle_exit_devtools_mode(&mut state);
+
+        assert!(
+            !*net_rx.borrow(),
+            "exit must not pause network polling while service monitoring is active"
+        );
+    }
+
+    #[test]
+    fn test_leave_network_panel_keeps_polling_when_service_monitoring() {
+        // Switching away from the Network panel must not pause network polling
+        // while a service-layer consumer needs HTTP profile entries.
+        let mut state = make_state_with_session();
+        state.devtools_view_state.active_panel = DevToolsPanel::Network;
+        let (net_tx, net_rx) = tokio::sync::watch::channel(false);
+        {
+            let handle = state.session_manager.selected_mut().unwrap();
+            handle.devtools_service_monitoring = true;
+            handle.network_pause_tx = Some(std::sync::Arc::new(net_tx));
+        }
+
+        handle_switch_panel(&mut state, DevToolsPanel::Inspector);
+
+        assert!(
+            !*net_rx.borrow(),
+            "leaving the Network panel must not pause polling while service monitoring is active"
         );
     }
 

--- a/crates/fdemon-app/src/handler/devtools/monitoring.rs
+++ b/crates/fdemon-app/src/handler/devtools/monitoring.rs
@@ -1,0 +1,337 @@
+//! Service-level DevTools monitoring handlers.
+//!
+//! These handlers back the `StartDevToolsMonitoring` / `StopDevToolsMonitoring`
+//! messages dispatched by [`crate::services::DevToolsService`] so headless
+//! consumers (e.g. an MCP server embedding the Engine) can collect telemetry
+//! without the TUI user entering DevTools mode. They reuse exactly the same
+//! `UpdateAction`s and pause channels as the TUI handlers in
+//! [`super`] (`handle_enter_devtools_mode` / `handle_switch_panel`).
+
+use crate::handler::{UpdateAction, UpdateResult};
+use crate::session::SessionId;
+use crate::state::AppState;
+use crate::state::UiMode;
+
+/// Handle `Message::StartDevToolsMonitoring`.
+///
+/// Marks the session for service-level monitoring and ensures the performance
+/// (memory sampling) and network (HTTP profile) polling tasks are running and
+/// unpaused:
+///
+/// - If a polling task is not running yet, the corresponding
+///   `StartPerformanceMonitoring` / `StartNetworkMonitoring` action is
+///   returned — the same actions the TUI dispatches on DevTools entry.
+/// - If a task is already running, its pause channel is sent `false`.
+/// - If the VM Service is not connected yet, only the flag is set; the
+///   `VmServiceConnected` handler starts monitoring once the VM attaches.
+///
+/// Frame timings ([`crate::session::PerformanceState::frame_history`]) are
+/// collected passively from the VM Service Extension stream whenever the VM is
+/// connected and do not require this handler.
+pub fn handle_start_devtools_monitoring(
+    state: &mut AppState,
+    session_id: SessionId,
+) -> UpdateResult {
+    // Read settings before the mutable session borrow.
+    let performance_refresh_ms = state.settings.devtools.performance_refresh_ms;
+    let allocation_profile_interval_ms = state.settings.devtools.allocation_profile_interval_ms;
+    let network_poll_interval_ms = state.settings.devtools.network_poll_interval_ms;
+
+    let Some(handle) = state.session_manager.get_mut(session_id) else {
+        tracing::warn!(
+            session_id = session_id,
+            "StartDevToolsMonitoring: unknown session — ignoring"
+        );
+        return UpdateResult::none();
+    };
+
+    handle.devtools_service_monitoring = true;
+
+    if !handle.session.vm_connected {
+        tracing::info!(
+            session_id = session_id,
+            "StartDevToolsMonitoring: VM Service not connected yet — monitoring \
+             will start automatically on VmServiceConnected"
+        );
+        return UpdateResult::none();
+    }
+
+    let mode = handle
+        .session
+        .launch_config
+        .as_ref()
+        .map(|c| c.mode)
+        .unwrap_or(crate::config::FlutterMode::Debug);
+
+    let mut actions = Vec::new();
+
+    // Performance polling (memory samples + allocation profile).
+    if handle.perf_shutdown_tx.is_none() {
+        actions.push(UpdateAction::StartPerformanceMonitoring {
+            session_id,
+            handle: None, // hydrated by process.rs
+            performance_refresh_ms,
+            allocation_profile_interval_ms,
+            mode,
+        });
+    } else if let Some(ref tx) = handle.perf_pause_tx {
+        let _ = tx.send(false); // unpause
+    }
+
+    // Network polling (HTTP profile). Skip when the `ext.dart.io.*` extensions
+    // are known to be unavailable (release mode) or a task is already running.
+    let network_extensions_unavailable = handle.session.network.extensions_available == Some(false);
+    if handle.network_shutdown_tx.is_none() {
+        if !network_extensions_unavailable {
+            actions.push(UpdateAction::StartNetworkMonitoring {
+                session_id,
+                handle: None, // hydrated by process.rs
+                poll_interval_ms: network_poll_interval_ms,
+                mode,
+            });
+        }
+    } else if let Some(ref tx) = handle.network_pause_tx {
+        let _ = tx.send(false); // unpause
+    }
+
+    UpdateResult::actions_vec(actions)
+}
+
+/// Handle `Message::StopDevToolsMonitoring`.
+///
+/// Clears the service-monitoring flag. When the TUI user is *not* currently
+/// viewing this session in DevTools mode, the performance and network polling
+/// loops are paused (the same pause channels `handle_exit_devtools_mode`
+/// uses). When the TUI *is* in DevTools mode on this session, pause state is
+/// left untouched so the TUI panels keep receiving data.
+pub fn handle_stop_devtools_monitoring(
+    state: &mut AppState,
+    session_id: SessionId,
+) -> UpdateResult {
+    let tui_devtools_active = state.ui_mode == UiMode::DevTools
+        && state.session_manager.selected_id() == Some(session_id);
+
+    let Some(handle) = state.session_manager.get_mut(session_id) else {
+        tracing::warn!(
+            session_id = session_id,
+            "StopDevToolsMonitoring: unknown session — ignoring"
+        );
+        return UpdateResult::none();
+    };
+
+    handle.devtools_service_monitoring = false;
+
+    if !tui_devtools_active {
+        if let Some(ref tx) = handle.perf_pause_tx {
+            let _ = tx.send(true); // pause
+        }
+        if let Some(ref tx) = handle.network_pause_tx {
+            let _ = tx.send(true); // pause
+        }
+    }
+
+    UpdateResult::none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handler::UpdateAction;
+    use crate::state::UiMode;
+
+    fn make_state_with_session() -> AppState {
+        let mut state = AppState::new();
+        let device = fdemon_daemon::Device {
+            id: "test-device".to_string(),
+            name: "Test Device".to_string(),
+            platform: "android".to_string(),
+            emulator: false,
+            category: None,
+            platform_type: None,
+            ephemeral: false,
+            emulator_id: None,
+            is_supported: true,
+            capabilities: None,
+        };
+        state.session_manager.create_session(&device).unwrap();
+        state
+    }
+
+    fn session_id(state: &AppState) -> SessionId {
+        state.session_manager.selected_id().unwrap()
+    }
+
+    #[test]
+    fn test_start_monitoring_unknown_session_is_noop() {
+        let mut state = make_state_with_session();
+        let result = handle_start_devtools_monitoring(&mut state, 9999);
+        assert!(result.action.is_none());
+        assert!(result.message.is_none());
+    }
+
+    #[test]
+    fn test_start_monitoring_vm_not_connected_sets_flag_only() {
+        let mut state = make_state_with_session();
+        let id = session_id(&state);
+
+        let result = handle_start_devtools_monitoring(&mut state, id);
+
+        assert!(
+            result.action.is_none(),
+            "no actions before the VM Service connects"
+        );
+        assert!(
+            state
+                .session_manager
+                .get(id)
+                .unwrap()
+                .devtools_service_monitoring,
+            "flag must be set so VmServiceConnected starts monitoring later"
+        );
+    }
+
+    #[test]
+    fn test_start_monitoring_dispatches_perf_and_network_actions() {
+        let mut state = make_state_with_session();
+        let id = session_id(&state);
+        state
+            .session_manager
+            .get_mut(id)
+            .unwrap()
+            .session
+            .vm_connected = true;
+
+        let result = handle_start_devtools_monitoring(&mut state, id);
+
+        let actions = result.actions();
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, UpdateAction::StartPerformanceMonitoring { session_id, .. } if *session_id == id)),
+            "expected StartPerformanceMonitoring, got {:?}",
+            actions
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, UpdateAction::StartNetworkMonitoring { session_id, .. } if *session_id == id)),
+            "expected StartNetworkMonitoring, got {:?}",
+            actions
+        );
+        assert!(
+            state
+                .session_manager
+                .get(id)
+                .unwrap()
+                .devtools_service_monitoring
+        );
+    }
+
+    #[test]
+    fn test_start_monitoring_skips_network_when_extensions_unavailable() {
+        let mut state = make_state_with_session();
+        let id = session_id(&state);
+        {
+            let handle = state.session_manager.get_mut(id).unwrap();
+            handle.session.vm_connected = true;
+            handle.session.network.extensions_available = Some(false);
+        }
+
+        let result = handle_start_devtools_monitoring(&mut state, id);
+
+        let actions = result.actions();
+        assert!(
+            !actions
+                .iter()
+                .any(|a| matches!(a, UpdateAction::StartNetworkMonitoring { .. })),
+            "network monitoring must not start when extensions are unavailable"
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, UpdateAction::StartPerformanceMonitoring { .. })),
+            "performance monitoring should still start"
+        );
+    }
+
+    #[test]
+    fn test_start_monitoring_unpauses_running_tasks_instead_of_restarting() {
+        let mut state = make_state_with_session();
+        let id = session_id(&state);
+
+        let (perf_shutdown_tx, _perf_shutdown_rx) = tokio::sync::watch::channel(false);
+        let (perf_pause_tx, perf_pause_rx) = tokio::sync::watch::channel(true);
+        let (net_shutdown_tx, _net_shutdown_rx) = tokio::sync::watch::channel(false);
+        let (net_pause_tx, net_pause_rx) = tokio::sync::watch::channel(true);
+        {
+            let handle = state.session_manager.get_mut(id).unwrap();
+            handle.session.vm_connected = true;
+            handle.perf_shutdown_tx = Some(std::sync::Arc::new(perf_shutdown_tx));
+            handle.perf_pause_tx = Some(std::sync::Arc::new(perf_pause_tx));
+            handle.network_shutdown_tx = Some(std::sync::Arc::new(net_shutdown_tx));
+            handle.network_pause_tx = Some(std::sync::Arc::new(net_pause_tx));
+        }
+
+        let result = handle_start_devtools_monitoring(&mut state, id);
+
+        assert!(
+            result.action.is_none(),
+            "tasks already running — no new start actions expected"
+        );
+        assert!(!*perf_pause_rx.borrow(), "perf polling must be unpaused");
+        assert!(!*net_pause_rx.borrow(), "network polling must be unpaused");
+    }
+
+    #[test]
+    fn test_stop_monitoring_clears_flag_and_pauses_outside_devtools() {
+        let mut state = make_state_with_session();
+        let id = session_id(&state);
+        state.ui_mode = UiMode::Normal;
+
+        let (perf_pause_tx, perf_pause_rx) = tokio::sync::watch::channel(false);
+        let (net_pause_tx, net_pause_rx) = tokio::sync::watch::channel(false);
+        {
+            let handle = state.session_manager.get_mut(id).unwrap();
+            handle.devtools_service_monitoring = true;
+            handle.perf_pause_tx = Some(std::sync::Arc::new(perf_pause_tx));
+            handle.network_pause_tx = Some(std::sync::Arc::new(net_pause_tx));
+        }
+
+        handle_stop_devtools_monitoring(&mut state, id);
+
+        let handle = state.session_manager.get(id).unwrap();
+        assert!(!handle.devtools_service_monitoring, "flag must be cleared");
+        assert!(*perf_pause_rx.borrow(), "perf polling must be paused");
+        assert!(*net_pause_rx.borrow(), "network polling must be paused");
+    }
+
+    #[test]
+    fn test_stop_monitoring_leaves_pause_state_when_tui_in_devtools() {
+        let mut state = make_state_with_session();
+        let id = session_id(&state);
+        state.ui_mode = UiMode::DevTools;
+
+        let (perf_pause_tx, perf_pause_rx) = tokio::sync::watch::channel(false);
+        {
+            let handle = state.session_manager.get_mut(id).unwrap();
+            handle.devtools_service_monitoring = true;
+            handle.perf_pause_tx = Some(std::sync::Arc::new(perf_pause_tx));
+        }
+
+        handle_stop_devtools_monitoring(&mut state, id);
+
+        let handle = state.session_manager.get(id).unwrap();
+        assert!(!handle.devtools_service_monitoring, "flag must be cleared");
+        assert!(
+            !*perf_pause_rx.borrow(),
+            "pause state must be left to the TUI when DevTools is active on this session"
+        );
+    }
+
+    #[test]
+    fn test_stop_monitoring_unknown_session_is_noop() {
+        let mut state = make_state_with_session();
+        let result = handle_stop_devtools_monitoring(&mut state, 9999);
+        assert!(result.action.is_none());
+    }
+}

--- a/crates/fdemon-app/src/handler/tests.rs
+++ b/crates/fdemon-app/src/handler/tests.rs
@@ -13710,3 +13710,63 @@ mod fetch_trigger_tests {
         );
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Embedder status badge (SetStatusBadge)
+// ─────────────────────────────────────────────────────────────────────────────
+
+mod status_badge_tests {
+    use super::*;
+    use crate::state::{StatusBadge, StatusBadgeKind};
+
+    #[test]
+    fn test_status_badge_defaults_to_none() {
+        let state = AppState::new();
+        assert!(state.status_badge.is_none(), "no badge by default");
+    }
+
+    #[test]
+    fn test_set_status_badge_stores_badge() {
+        let mut state = AppState::new();
+
+        let result = update(
+            &mut state,
+            Message::SetStatusBadge {
+                badge: Some(StatusBadge::new("MCP 2 clients", StatusBadgeKind::Active)),
+            },
+        );
+
+        assert!(result.action.is_none(), "SetStatusBadge has no side effect");
+        assert!(result.message.is_none());
+        let badge = state.status_badge.as_ref().expect("badge must be stored");
+        assert_eq!(badge.text, "MCP 2 clients");
+        assert_eq!(badge.kind, StatusBadgeKind::Active);
+    }
+
+    #[test]
+    fn test_set_status_badge_replaces_existing_badge() {
+        let mut state = AppState::new();
+        state.status_badge = Some(StatusBadge::new("MCP 1 client", StatusBadgeKind::Info));
+
+        update(
+            &mut state,
+            Message::SetStatusBadge {
+                badge: Some(StatusBadge::new("MCP 3 clients", StatusBadgeKind::Warn)),
+            },
+        );
+
+        let badge = state.status_badge.as_ref().unwrap();
+        assert_eq!(badge.text, "MCP 3 clients");
+        assert_eq!(badge.kind, StatusBadgeKind::Warn);
+    }
+
+    #[test]
+    fn test_set_status_badge_none_clears_badge() {
+        let mut state = AppState::new();
+        state.status_badge = Some(StatusBadge::new("MCP 2 clients", StatusBadgeKind::Active));
+
+        update(&mut state, Message::SetStatusBadge { badge: None });
+
+        assert!(state.status_badge.is_none(), "badge must be cleared");
+    }
+}

--- a/crates/fdemon-app/src/handler/update.rs
+++ b/crates/fdemon-app/src/handler/update.rs
@@ -1733,7 +1733,18 @@ pub fn update(state: &mut AppState, message: Message) -> UpdateResult {
             // process.rs hydrates `StartPerformanceMonitoring.handle` and
             // `ToggleProfileWidgetBuilds.vm_handle` with the VmRequestHandle
             // from the session before dispatch.
-            let perf_action = if state.ui_mode == UiMode::DevTools {
+            //
+            // Service-layer monitoring: when a headless consumer requested
+            // telemetry via `StartDevToolsMonitoring` before the VM connected,
+            // start the polling tasks now even though the TUI is not in
+            // DevTools mode (the `VmServicePerformanceMonitoringStarted`
+            // handler unpauses based on the same flag).
+            let service_monitoring = state
+                .session_manager
+                .get(session_id)
+                .map(|h| h.devtools_service_monitoring)
+                .unwrap_or(false);
+            let perf_action = if state.ui_mode == UiMode::DevTools || service_monitoring {
                 Some(UpdateAction::StartPerformanceMonitoring {
                     session_id,
                     handle: None, // hydrated by process.rs
@@ -1769,6 +1780,27 @@ pub fn update(state: &mut AppState, message: Message) -> UpdateResult {
             let mut extra_actions = Vec::new();
             if let Some(action) = auto_enable_action {
                 extra_actions.push(action);
+            }
+
+            // Service-layer monitoring also needs the network polling task
+            // (the TUI only starts it on Network-panel entry). The network
+            // task was torn down at the top of this arm, so it is never
+            // already running here. Skip when the `ext.dart.io.*` extensions
+            // are known to be unavailable (release mode).
+            if service_monitoring {
+                let network_extensions_unavailable = state
+                    .session_manager
+                    .get(session_id)
+                    .map(|h| h.session.network.extensions_available == Some(false))
+                    .unwrap_or(true);
+                if !network_extensions_unavailable {
+                    extra_actions.push(UpdateAction::StartNetworkMonitoring {
+                        session_id,
+                        handle: None, // hydrated by process.rs
+                        poll_interval_ms: state.settings.devtools.network_poll_interval_ms,
+                        mode,
+                    });
+                }
             }
 
             UpdateResult {
@@ -1851,18 +1883,44 @@ pub fn update(state: &mut AppState, message: Message) -> UpdateResult {
             }
 
             // Re-subscribe to VM streams and restart performance monitoring only
-            // when DevTools is already active. If the user is viewing logs, the
-            // monitoring task will be started lazily when they open DevTools.
+            // when DevTools is already active or a service-layer consumer has
+            // requested telemetry (`StartDevToolsMonitoring`). If the user is
+            // viewing logs, the monitoring task will be started lazily when
+            // they open DevTools.
             // `process.rs` will hydrate `handle` with the VmRequestHandle from the
             // session before dispatching the action to handle_action.
-            if state.ui_mode == UiMode::DevTools {
-                UpdateResult::action(UpdateAction::StartPerformanceMonitoring {
+            let service_monitoring = state
+                .session_manager
+                .get(session_id)
+                .map(|h| h.devtools_service_monitoring)
+                .unwrap_or(false);
+            if state.ui_mode == UiMode::DevTools || service_monitoring {
+                let mut actions = vec![UpdateAction::StartPerformanceMonitoring {
                     session_id,
                     handle: None, // hydrated by process.rs
                     performance_refresh_ms,
                     allocation_profile_interval_ms,
                     mode,
-                })
+                }];
+                // The old network polling task was aborted above; restart it
+                // for service-layer consumers (the TUI restarts it on its own
+                // via Network-panel entry).
+                if service_monitoring {
+                    let network_extensions_unavailable = state
+                        .session_manager
+                        .get(session_id)
+                        .map(|h| h.session.network.extensions_available == Some(false))
+                        .unwrap_or(true);
+                    if !network_extensions_unavailable {
+                        actions.push(UpdateAction::StartNetworkMonitoring {
+                            session_id,
+                            handle: None, // hydrated by process.rs
+                            poll_interval_ms: state.settings.devtools.network_poll_interval_ms,
+                            mode,
+                        });
+                    }
+                }
+                UpdateResult::actions_vec(actions)
             } else {
                 UpdateResult::none()
             }
@@ -2130,7 +2188,35 @@ pub fn update(state: &mut AppState, message: Message) -> UpdateResult {
                         }
                     }
                 }
+
+                // Service-layer monitoring (headless embedders): the memory
+                // tick must run regardless of the TUI's UI mode while a
+                // consumer has requested telemetry via StartDevToolsMonitoring.
+                if handle.devtools_service_monitoring {
+                    if let Some(ref tx) = handle.perf_pause_tx {
+                        let _ = tx.send(false);
+                    }
+                }
             }
+            UpdateResult::none()
+        }
+
+        // ─────────────────────────────────────────────────────────
+        // Service-layer DevTools monitoring (headless embedders)
+        // ─────────────────────────────────────────────────────────
+        Message::StartDevToolsMonitoring { session_id } => {
+            devtools::monitoring::handle_start_devtools_monitoring(state, session_id)
+        }
+
+        Message::StopDevToolsMonitoring { session_id } => {
+            devtools::monitoring::handle_stop_devtools_monitoring(state, session_id)
+        }
+
+        // ─────────────────────────────────────────────────────────
+        // Embedder status badge
+        // ─────────────────────────────────────────────────────────
+        Message::SetStatusBadge { badge } => {
+            state.status_badge = badge;
             UpdateResult::none()
         }
 

--- a/crates/fdemon-app/src/lib.rs
+++ b/crates/fdemon-app/src/lib.rs
@@ -46,6 +46,8 @@
 //! - [`services::LogService`] - Log buffer access
 //! - [`services::StateService`] - App state access
 //! - [`services::SessionService`] - Session listing, start/stop by id, DevTools URLs
+//! - [`services::DevToolsService`] - Per-session DevTools telemetry (frames,
+//!   memory, network, widget tree) and headless monitoring control
 //! - [`services::ProjectService`] - Project operations (`pub get`, `clean`)
 //!
 //! ### Configuration
@@ -97,8 +99,8 @@ pub use plugin::EnginePlugin;
 pub use session::{Session, SessionHandle, SessionId};
 pub use session_manager::{SessionManager, MAX_SESSIONS};
 pub use state::{
-    AppState, DevToolsError, DevToolsPanel, DevToolsViewState, InspectorState, TagFilterUiState,
-    ToastLevel,
+    AppState, DevToolsError, DevToolsPanel, DevToolsViewState, InspectorState, StatusBadge,
+    StatusBadgeKind, TagFilterUiState, ToastLevel,
 };
 
 // Re-export action types used by TUI for startup

--- a/crates/fdemon-app/src/message.rs
+++ b/crates/fdemon-app/src/message.rs
@@ -1362,6 +1362,44 @@ pub enum Message {
     },
 
     // ─────────────────────────────────────────────────────────────────────────
+    // Service-layer DevTools monitoring (headless embedders)
+    // ─────────────────────────────────────────────────────────────────────────
+    /// Start DevTools telemetry collection for a session without requiring the
+    /// TUI user to enter DevTools mode.
+    ///
+    /// Dispatched by [`crate::services::DevToolsService::start_monitoring`].
+    /// Sets `SessionHandle::devtools_service_monitoring`, spawns the
+    /// performance/network polling tasks if they are not running (the same
+    /// `StartPerformanceMonitoring` / `StartNetworkMonitoring` actions the TUI
+    /// uses), and unpauses already-running tasks. While the flag is set, the
+    /// TUI's pause-on-DevTools-exit paths leave the perf/network polling loops
+    /// running so headless consumers keep receiving samples.
+    ///
+    /// If the VM Service is not yet connected, only the flag is set; the
+    /// `VmServiceConnected` handler then starts monitoring automatically.
+    StartDevToolsMonitoring { session_id: SessionId },
+
+    /// Stop service-level DevTools telemetry collection for a session.
+    ///
+    /// Clears `SessionHandle::devtools_service_monitoring` and pauses the
+    /// perf/network polling loops — unless the TUI user is currently viewing
+    /// that session in DevTools mode, in which case the pause state is left
+    /// for the TUI handlers to manage.
+    StopDevToolsMonitoring { session_id: SessionId },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Embedder status badge
+    // ─────────────────────────────────────────────────────────────────────────
+    /// Set or clear the generic embedder status badge in the main header.
+    ///
+    /// `Some(badge)` shows the badge near the right edge of the header;
+    /// `None` clears it. Intended for external embedders (e.g. an MCP server
+    /// showing `"MCP 2 clients"`); fdemon itself never sets a badge.
+    SetStatusBadge {
+        badge: Option<crate::state::StatusBadge>,
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Settings — Dart Defines Modal (v1-refinements Phase 2, Task 02)
     // ─────────────────────────────────────────────────────────────────────────
     /// Open the dart defines editor modal for the launch config at `config_idx`.

--- a/crates/fdemon-app/src/services/devtools_service.rs
+++ b/crates/fdemon-app/src/services/devtools_service.rs
@@ -1,0 +1,693 @@
+//! DevTools telemetry access for external consumers
+//!
+//! This module provides the [`DevToolsService`] trait so remote-control
+//! consumers (e.g. an MCP server giving AI agents diagnosis of a running
+//! Flutter app) can read per-session DevTools telemetry — frame timings,
+//! memory samples, HTTP profile entries, and the widget tree — without
+//! direct access to the Engine and without any TUI interaction.
+//!
+//! ## How collection is gated (and how this service works around it)
+//!
+//! - **Frame timings** arrive passively on the VM Service Extension stream
+//!   whenever the VM is connected (the per-session event forwarder always
+//!   parses `Flutter.Frame` events). No TUI interaction is required; recent
+//!   frames and jank stats are available as soon as the app is running in
+//!   debug/profile mode.
+//! - **Memory samples** come from the performance polling task, which the TUI
+//!   only spawns/unpauses while DevTools mode is active. Call
+//!   [`DevToolsService::start_monitoring`] to start (and keep) it running
+//!   headlessly.
+//! - **Network requests** come from the network polling task, which the TUI
+//!   only starts when the Network panel is opened. `start_monitoring` starts
+//!   it too (when the `ext.dart.io.*` extensions are available).
+//! - **The widget tree** is fetched on demand. Reads come from the cache the
+//!   Engine syncs from the inspector view-state; trigger a fresh fetch with
+//!   [`DevToolsService::fetch_widget_tree`]. The tree is only available for
+//!   the **currently selected** session — fetch results for background
+//!   sessions are discarded by the TEA handler.
+//!
+//! Following the [`super::session_service`] precedent: cheap reads come from
+//! [`SharedState`] snapshots (synced by the Engine after each TEA cycle);
+//! actions are dispatched as [`Message`]s through the Engine's message
+//! channel, reusing the same handler machinery as the keyboard user.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+
+use super::state_service::SharedState;
+use crate::message::Message;
+use crate::session::SessionId;
+use fdemon_core::network::HttpProfileEntry;
+use fdemon_core::performance::{FrameTiming, MemorySample, PerformanceStats};
+use fdemon_core::prelude::*;
+use fdemon_core::DiagnosticsNode;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Snapshot caps (sync cost control)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Maximum frame timings copied into each [`DevToolsSessionSnapshot`].
+///
+/// 300 frames ≈ 5 seconds at 60 FPS — enough for jank diagnosis while keeping
+/// the per-TEA-cycle clone cost negligible (the full per-session ring buffer
+/// holds 1 800 frames).
+pub const DEVTOOLS_SNAPSHOT_MAX_FRAMES: usize = 300;
+
+/// Maximum memory samples copied into each [`DevToolsSessionSnapshot`].
+///
+/// 120 samples ≈ 1 minute at the default 500 ms memory poll interval.
+pub const DEVTOOLS_SNAPSHOT_MAX_MEMORY_SAMPLES: usize = 120;
+
+/// Maximum HTTP profile entries copied into each [`DevToolsSessionSnapshot`].
+///
+/// 100 most-recent requests; the per-session buffer holds up to 500.
+pub const DEVTOOLS_SNAPSHOT_MAX_NETWORK_ENTRIES: usize = 100;
+
+/// Poll interval used by [`SharedDevToolsService::fetch_widget_tree`] while
+/// waiting for the Engine to sync a fresh tree into [`SharedState`].
+const WIDGET_TREE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Freshness window for the cached widget tree.
+///
+/// Mirrors the 2-second `RequestWidgetTree` cooldown in
+/// `InspectorState::is_fetch_debounced`: a dispatch inside this window would
+/// be debounced by the handler anyway, so a cached tree younger than this is
+/// returned immediately.
+const WIDGET_TREE_FRESHNESS: Duration = Duration::from_secs(2);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Snapshot types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Point-in-time view of one session's DevTools telemetry.
+///
+/// Synced from the per-session ring buffers (`session.performance`,
+/// `session.memory`, `session.network`) into [`SharedState::devtools`] by the
+/// Engine after each message-processing cycle. Telemetry vectors are capped by
+/// the `DEVTOOLS_SNAPSHOT_MAX_*` constants (most recent entries are kept).
+#[derive(Debug, Clone)]
+pub struct DevToolsSessionSnapshot {
+    pub session_id: SessionId,
+    /// Whether the VM Service WebSocket is connected for this session.
+    pub vm_connected: bool,
+    /// Whether the performance polling task (memory sampling) is running.
+    ///
+    /// Note: the task may still be *paused*; use
+    /// [`DevToolsService::start_monitoring`] to ensure it is running and
+    /// unpaused.
+    pub perf_monitoring_active: bool,
+    /// Whether the network polling task is running.
+    pub network_monitoring_active: bool,
+    /// Whether the `ext.dart.io.*` network extensions are available
+    /// (`None` = not probed yet, `Some(false)` = release mode).
+    pub network_extensions_available: Option<bool>,
+    /// Aggregated frame statistics (FPS, jank count, avg/p95/max frame time).
+    pub stats: PerformanceStats,
+    /// Most recent frame timings (oldest first), capped at
+    /// [`DEVTOOLS_SNAPSHOT_MAX_FRAMES`].
+    pub recent_frames: Vec<FrameTiming>,
+    /// Most recent memory samples (oldest first), capped at
+    /// [`DEVTOOLS_SNAPSHOT_MAX_MEMORY_SAMPLES`].
+    pub memory_samples: Vec<MemorySample>,
+    /// Most recent HTTP request summaries (oldest first), capped at
+    /// [`DEVTOOLS_SNAPSHOT_MAX_NETWORK_ENTRIES`].
+    pub network_requests: Vec<HttpProfileEntry>,
+}
+
+/// Recent frame timings together with the aggregated jank statistics.
+#[derive(Debug, Clone)]
+pub struct PerformanceFramesSnapshot {
+    /// Most recent frame timings (oldest first).
+    pub frames: Vec<FrameTiming>,
+    /// Aggregated statistics over the session's full frame history.
+    pub stats: PerformanceStats,
+}
+
+/// Cached widget tree for the currently selected session.
+///
+/// Synced from `AppState::devtools_view_state.inspector` by the Engine. The
+/// tree is wrapped in an [`Arc`] and re-cloned into [`SharedState`] only when
+/// a fetch starts/completes, so steady-state sync cost is one pointer compare.
+#[derive(Debug, Clone)]
+pub struct WidgetTreeSnapshot {
+    /// The session the inspector view-state currently tracks (the selected one).
+    pub session_id: SessionId,
+    /// When the most recent fetch was *started* (`None` = never fetched).
+    pub fetched_at: Option<Instant>,
+    /// Whether a fetch is currently in flight.
+    pub loading: bool,
+    /// Error message from the most recent failed fetch.
+    pub error: Option<String>,
+    /// Root of the widget tree, if a fetch has completed successfully.
+    pub root: Option<Arc<DiagnosticsNode>>,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-session DevTools telemetry reads and monitoring control
+///
+/// Both TUI-side consumers and external embedders (MCP handlers) use this
+/// trait. All methods are headless-usable: none require the TUI user to enter
+/// DevTools mode.
+#[trait_variant::make(DevToolsService: Send)]
+pub trait LocalDevToolsService {
+    /// Telemetry snapshots for all active sessions.
+    async fn list_snapshots(&self) -> Vec<DevToolsSessionSnapshot>;
+
+    /// Telemetry snapshot for one session (`None` = unknown session id).
+    async fn devtools_snapshot(&self, session_id: SessionId) -> Option<DevToolsSessionSnapshot>;
+
+    /// Recent frame timings plus aggregated jank stats for one session.
+    ///
+    /// Frames are collected passively while the VM Service is connected, so
+    /// this works without `start_monitoring`.
+    async fn performance_frames(&self, session_id: SessionId) -> Option<PerformanceFramesSnapshot>;
+
+    /// Recent memory samples for one session (oldest first).
+    ///
+    /// Empty until [`Self::start_monitoring`] (or the TUI user entering
+    /// DevTools mode) starts the memory polling task.
+    async fn memory_samples(&self, session_id: SessionId) -> Option<Vec<MemorySample>>;
+
+    /// Recent HTTP request summaries for one session (oldest first).
+    ///
+    /// Empty until [`Self::start_monitoring`] (or the TUI user opening the
+    /// Network panel) starts the network polling task.
+    async fn network_requests(&self, session_id: SessionId) -> Option<Vec<HttpProfileEntry>>;
+
+    /// Start (and keep) DevTools telemetry collection for a session.
+    ///
+    /// Dispatches [`Message::StartDevToolsMonitoring`] through the Engine's
+    /// message channel. Success means the request was queued; the polling
+    /// tasks spawn asynchronously (immediately when the VM is connected,
+    /// otherwise on the next `VmServiceConnected`). While active, the TUI's
+    /// pause-on-DevTools-exit paths leave polling running.
+    async fn start_monitoring(&self, session_id: SessionId) -> Result<()>;
+
+    /// Stop service-level telemetry collection for a session.
+    ///
+    /// Polling is paused unless the TUI user is actively viewing that session
+    /// in DevTools mode.
+    async fn stop_monitoring(&self, session_id: SessionId) -> Result<()>;
+
+    /// The cached widget tree, if it belongs to `session_id`.
+    ///
+    /// The inspector cache tracks the **selected** session only; `None` is
+    /// returned for background sessions or when no fetch has completed yet.
+    async fn cached_widget_tree(&self, session_id: SessionId) -> Option<Arc<DiagnosticsNode>>;
+
+    /// Trigger a widget tree fetch without waiting for the result.
+    ///
+    /// Dispatches [`Message::RequestWidgetTree`]; the handler debounces
+    /// requests within 2 seconds of the previous fetch. Read the result later
+    /// via [`Self::cached_widget_tree`].
+    async fn request_widget_tree(&self, session_id: SessionId) -> Result<()>;
+
+    /// Fetch the widget tree and await the result.
+    ///
+    /// Contract:
+    /// 1. If a cached tree for `session_id` is younger than the handler's
+    ///    2-second fetch cooldown, it is returned immediately (a dispatch
+    ///    would be debounced anyway).
+    /// 2. Otherwise [`Message::RequestWidgetTree`] is dispatched and the
+    ///    synced cache is polled every 50 ms until a fresh tree (or a fetch
+    ///    error) appears, or `timeout` elapses.
+    ///
+    /// Requirements: the session must be the **selected** session with a
+    /// connected VM Service running in debug mode — otherwise the fetch
+    /// result never reaches the cache and this returns a timeout error.
+    async fn fetch_widget_tree(
+        &self,
+        session_id: SessionId,
+        timeout: Duration,
+    ) -> Result<Arc<DiagnosticsNode>>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SharedState-backed implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Implementation backed by [`SharedState`] snapshots and the Engine's
+/// message channel. Cheap to construct and `Send + 'static`, so it can be
+/// moved into spawned tokio tasks.
+pub struct SharedDevToolsService {
+    state: Arc<SharedState>,
+    msg_tx: mpsc::Sender<Message>,
+}
+
+impl SharedDevToolsService {
+    pub fn new(state: Arc<SharedState>, msg_tx: mpsc::Sender<Message>) -> Self {
+        Self { state, msg_tx }
+    }
+
+    /// Read the widget-tree cache if it tracks `session_id`.
+    async fn widget_tree_slot(&self, session_id: SessionId) -> Option<WidgetTreeSnapshot> {
+        self.state
+            .widget_tree
+            .read()
+            .await
+            .as_ref()
+            .filter(|slot| slot.session_id == session_id)
+            .cloned()
+    }
+
+    /// Read the synced telemetry snapshot for one session.
+    ///
+    /// Inherent helper so trait methods can share it without ambiguous
+    /// `self.devtools_snapshot(..)` calls (both trait variants would apply).
+    async fn snapshot_for(&self, session_id: SessionId) -> Option<DevToolsSessionSnapshot> {
+        self.state
+            .devtools
+            .read()
+            .await
+            .iter()
+            .find(|s| s.session_id == session_id)
+            .cloned()
+    }
+
+    /// Dispatch a message through the Engine's channel.
+    async fn dispatch(&self, message: Message, what: &'static str) -> Result<()> {
+        self.msg_tx
+            .send(message)
+            .await
+            .map_err(|_| Error::channel_send(what))
+    }
+}
+
+impl DevToolsService for SharedDevToolsService {
+    async fn list_snapshots(&self) -> Vec<DevToolsSessionSnapshot> {
+        self.state.devtools.read().await.clone()
+    }
+
+    async fn devtools_snapshot(&self, session_id: SessionId) -> Option<DevToolsSessionSnapshot> {
+        self.snapshot_for(session_id).await
+    }
+
+    async fn performance_frames(&self, session_id: SessionId) -> Option<PerformanceFramesSnapshot> {
+        self.snapshot_for(session_id)
+            .await
+            .map(|s| PerformanceFramesSnapshot {
+                frames: s.recent_frames,
+                stats: s.stats,
+            })
+    }
+
+    async fn memory_samples(&self, session_id: SessionId) -> Option<Vec<MemorySample>> {
+        self.snapshot_for(session_id)
+            .await
+            .map(|s| s.memory_samples)
+    }
+
+    async fn network_requests(&self, session_id: SessionId) -> Option<Vec<HttpProfileEntry>> {
+        self.snapshot_for(session_id)
+            .await
+            .map(|s| s.network_requests)
+    }
+
+    async fn start_monitoring(&self, session_id: SessionId) -> Result<()> {
+        self.dispatch(
+            Message::StartDevToolsMonitoring { session_id },
+            "start devtools monitoring command",
+        )
+        .await
+    }
+
+    async fn stop_monitoring(&self, session_id: SessionId) -> Result<()> {
+        self.dispatch(
+            Message::StopDevToolsMonitoring { session_id },
+            "stop devtools monitoring command",
+        )
+        .await
+    }
+
+    async fn cached_widget_tree(&self, session_id: SessionId) -> Option<Arc<DiagnosticsNode>> {
+        self.widget_tree_slot(session_id).await.and_then(|s| s.root)
+    }
+
+    async fn request_widget_tree(&self, session_id: SessionId) -> Result<()> {
+        self.dispatch(
+            Message::RequestWidgetTree { session_id },
+            "request widget tree command",
+        )
+        .await
+    }
+
+    async fn fetch_widget_tree(
+        &self,
+        session_id: SessionId,
+        timeout: Duration,
+    ) -> Result<Arc<DiagnosticsNode>> {
+        // Fast path: a fetch completed within the handler's cooldown window —
+        // a new dispatch would be debounced, so return the cached tree.
+        let baseline = self.widget_tree_slot(session_id).await;
+        if let Some(ref slot) = baseline {
+            if !slot.loading {
+                if let (Some(at), Some(root)) = (slot.fetched_at, slot.root.as_ref()) {
+                    if at.elapsed() < WIDGET_TREE_FRESHNESS {
+                        return Ok(root.clone());
+                    }
+                }
+            }
+        }
+        let baseline_fetched_at = baseline.and_then(|s| s.fetched_at);
+
+        self.dispatch(
+            Message::RequestWidgetTree { session_id },
+            "request widget tree command",
+        )
+        .await?;
+
+        let deadline = Instant::now() + timeout;
+        loop {
+            tokio::time::sleep(WIDGET_TREE_POLL_INTERVAL).await;
+
+            if let Some(slot) = self.widget_tree_slot(session_id).await {
+                // A new fetch has started (fetched_at advanced) and finished
+                // (loading cleared): report its outcome.
+                if !slot.loading && slot.fetched_at != baseline_fetched_at {
+                    if let Some(error) = slot.error {
+                        return Err(Error::vm_service(format!(
+                            "widget tree fetch failed: {error}"
+                        )));
+                    }
+                    if let Some(root) = slot.root {
+                        return Ok(root);
+                    }
+                }
+            }
+
+            if Instant::now() >= deadline {
+                return Err(Error::vm_service(format!(
+                    "widget tree fetch timed out after {timeout:?} — the session must be \
+                     the selected one with a connected VM Service in debug mode"
+                )));
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    // Import only the Send-variant trait: `SharedDevToolsService` implements
+    // both variants (Local via the trait_variant blanket impl), so importing
+    // both would make plain method-call syntax ambiguous.
+    use super::{
+        DevToolsService, DevToolsSessionSnapshot, SharedDevToolsService, WidgetTreeSnapshot,
+    };
+    use crate::message::Message;
+    use crate::services::SharedState;
+    use crate::session::SessionId;
+    use fdemon_core::performance::{FrameTiming, MemorySample, PerformanceStats};
+    use fdemon_core::DiagnosticsNode;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+    use tokio::sync::mpsc;
+
+    fn frame(number: u64) -> FrameTiming {
+        FrameTiming {
+            number,
+            build_micros: 5_000,
+            raster_micros: 5_000,
+            elapsed_micros: 10_000,
+            timestamp: chrono::Local::now(),
+            phases: None,
+            shader_compilation: false,
+        }
+    }
+
+    fn memory_sample() -> MemorySample {
+        MemorySample {
+            dart_heap: 1024,
+            dart_native: 64,
+            raster_cache: 0,
+            allocated: 2048,
+            rss: 0,
+            timestamp: chrono::Local::now(),
+        }
+    }
+
+    fn snapshot(session_id: SessionId) -> DevToolsSessionSnapshot {
+        DevToolsSessionSnapshot {
+            session_id,
+            vm_connected: true,
+            perf_monitoring_active: true,
+            network_monitoring_active: false,
+            network_extensions_available: Some(true),
+            stats: PerformanceStats::default(),
+            recent_frames: vec![frame(1), frame(2)],
+            memory_samples: vec![memory_sample()],
+            network_requests: Vec::new(),
+        }
+    }
+
+    fn create_service() -> (
+        SharedDevToolsService,
+        mpsc::Receiver<Message>,
+        Arc<SharedState>,
+    ) {
+        let state = Arc::new(SharedState::new(100));
+        let (tx, rx) = mpsc::channel(10);
+        let service = SharedDevToolsService::new(state.clone(), tx);
+        (service, rx, state)
+    }
+
+    fn tree_root(description: &str) -> Arc<DiagnosticsNode> {
+        Arc::new(DiagnosticsNode {
+            description: description.to_string(),
+            ..Default::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn test_list_snapshots_empty_by_default() {
+        let (service, _rx, _state) = create_service();
+        assert!(service.list_snapshots().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_devtools_snapshot_returns_synced_data() {
+        let (service, _rx, state) = create_service();
+        *state.devtools.write().await = vec![snapshot(1), snapshot(2)];
+
+        let snap = service.devtools_snapshot(2).await.unwrap();
+        assert_eq!(snap.session_id, 2);
+        assert!(snap.vm_connected);
+        assert_eq!(snap.recent_frames.len(), 2);
+
+        assert!(service.devtools_snapshot(99).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_performance_frames_returns_frames_and_stats() {
+        let (service, _rx, state) = create_service();
+        let mut snap = snapshot(1);
+        snap.stats.jank_count = 3;
+        *state.devtools.write().await = vec![snap];
+
+        let perf = service.performance_frames(1).await.unwrap();
+        assert_eq!(perf.frames.len(), 2);
+        assert_eq!(perf.frames[0].number, 1);
+        assert_eq!(perf.stats.jank_count, 3);
+
+        assert!(service.performance_frames(99).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_memory_samples_and_network_requests_reads() {
+        let (service, _rx, state) = create_service();
+        *state.devtools.write().await = vec![snapshot(7)];
+
+        assert_eq!(service.memory_samples(7).await.unwrap().len(), 1);
+        assert!(service.network_requests(7).await.unwrap().is_empty());
+        assert!(service.memory_samples(8).await.is_none());
+        assert!(service.network_requests(8).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_start_monitoring_sends_message() {
+        let (service, mut rx, _state) = create_service();
+
+        service.start_monitoring(5).await.unwrap();
+
+        match rx.try_recv().unwrap() {
+            Message::StartDevToolsMonitoring { session_id } => assert_eq!(session_id, 5),
+            other => panic!("expected StartDevToolsMonitoring, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stop_monitoring_sends_message() {
+        let (service, mut rx, _state) = create_service();
+
+        service.stop_monitoring(5).await.unwrap();
+
+        match rx.try_recv().unwrap() {
+            Message::StopDevToolsMonitoring { session_id } => assert_eq!(session_id, 5),
+            other => panic!("expected StopDevToolsMonitoring, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_with_closed_channel_returns_error() {
+        let (service, rx, _state) = create_service();
+        drop(rx);
+
+        assert!(service.start_monitoring(1).await.is_err());
+        assert!(service.stop_monitoring(1).await.is_err());
+        assert!(service.request_widget_tree(1).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_request_widget_tree_sends_message() {
+        let (service, mut rx, _state) = create_service();
+
+        service.request_widget_tree(3).await.unwrap();
+
+        match rx.try_recv().unwrap() {
+            Message::RequestWidgetTree { session_id } => assert_eq!(session_id, 3),
+            other => panic!("expected RequestWidgetTree, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cached_widget_tree_filters_by_session() {
+        let (service, _rx, state) = create_service();
+        *state.widget_tree.write().await = Some(WidgetTreeSnapshot {
+            session_id: 1,
+            fetched_at: Some(Instant::now()),
+            loading: false,
+            error: None,
+            root: Some(tree_root("RootWidget")),
+        });
+
+        let root = service.cached_widget_tree(1).await.unwrap();
+        assert_eq!(root.description, "RootWidget");
+        assert!(
+            service.cached_widget_tree(2).await.is_none(),
+            "cache for session 1 must not be returned for session 2"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_widget_tree_fast_path_returns_fresh_cache_without_dispatch() {
+        let (service, mut rx, state) = create_service();
+        *state.widget_tree.write().await = Some(WidgetTreeSnapshot {
+            session_id: 1,
+            fetched_at: Some(Instant::now()), // fresh — inside cooldown window
+            loading: false,
+            error: None,
+            root: Some(tree_root("FreshRoot")),
+        });
+
+        let root = service
+            .fetch_widget_tree(1, Duration::from_millis(500))
+            .await
+            .unwrap();
+
+        assert_eq!(root.description, "FreshRoot");
+        assert!(
+            rx.try_recv().is_err(),
+            "fresh cache must short-circuit without dispatching RequestWidgetTree"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_widget_tree_awaits_synced_result() {
+        let (service, mut rx, state) = create_service();
+
+        // Simulate the Engine: consume the RequestWidgetTree dispatch, then
+        // sync a completed fetch into SharedState.
+        let responder_state = state.clone();
+        let responder = tokio::spawn(async move {
+            let msg = rx.recv().await.expect("dispatch expected");
+            assert!(matches!(msg, Message::RequestWidgetTree { session_id: 4 }));
+            *responder_state.widget_tree.write().await = Some(WidgetTreeSnapshot {
+                session_id: 4,
+                fetched_at: Some(Instant::now()),
+                loading: false,
+                error: None,
+                root: Some(tree_root("FetchedRoot")),
+            });
+        });
+
+        let root = service
+            .fetch_widget_tree(4, Duration::from_secs(2))
+            .await
+            .unwrap();
+
+        assert_eq!(root.description, "FetchedRoot");
+        responder.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_widget_tree_surfaces_fetch_error() {
+        let (service, mut rx, state) = create_service();
+
+        let responder_state = state.clone();
+        let responder = tokio::spawn(async move {
+            let _ = rx.recv().await;
+            *responder_state.widget_tree.write().await = Some(WidgetTreeSnapshot {
+                session_id: 4,
+                fetched_at: Some(Instant::now()),
+                loading: false,
+                error: Some("isolate not found".to_string()),
+                root: None,
+            });
+        });
+
+        let err = service
+            .fetch_widget_tree(4, Duration::from_secs(2))
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("isolate not found"),
+            "error must carry the fetch failure reason, got: {err}"
+        );
+        responder.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_widget_tree_times_out_when_no_result_arrives() {
+        let (service, mut rx, _state) = create_service();
+
+        // Consume the dispatch but never sync a result.
+        let responder = tokio::spawn(async move {
+            let _ = rx.recv().await;
+            // Keep the receiver alive long enough for the fetch to time out.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        });
+
+        let err = service
+            .fetch_widget_tree(1, Duration::from_millis(150))
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("timed out"),
+            "expected timeout error, got: {err}"
+        );
+        responder.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_devtools_service_usable_from_spawned_task() {
+        let (service, mut rx, _state) = create_service();
+
+        let handle = tokio::spawn(async move { service.start_monitoring(1).await });
+        handle.await.unwrap().unwrap();
+
+        assert!(matches!(
+            rx.try_recv().unwrap(),
+            Message::StartDevToolsMonitoring { .. }
+        ));
+    }
+}

--- a/crates/fdemon-app/src/services/mod.rs
+++ b/crates/fdemon-app/src/services/mod.rs
@@ -31,9 +31,12 @@
 //! - [`LogService`]: Log buffer access and filtering
 //! - [`StateService`]: App state and device queries
 //! - [`SessionService`]: Session listing, start/stop by id, DevTools URLs
+//! - [`DevToolsService`]: Per-session DevTools telemetry (frames, memory,
+//!   network, widget tree) and headless monitoring control
 //! - [`ProjectService`]: Project-level operations (`pub get`, `clean`)
 
 pub mod clipboard;
+mod devtools_service;
 mod flutter_controller;
 mod log_service;
 mod project_service;
@@ -43,6 +46,12 @@ mod state_service;
 #[cfg(test)]
 pub use clipboard::MemoryClipboard;
 pub use clipboard::{create_clipboard, Clipboard, ClipboardInit, NullClipboard, SystemClipboard};
+
+pub use devtools_service::{
+    DevToolsService, DevToolsSessionSnapshot, LocalDevToolsService, PerformanceFramesSnapshot,
+    SharedDevToolsService, WidgetTreeSnapshot, DEVTOOLS_SNAPSHOT_MAX_FRAMES,
+    DEVTOOLS_SNAPSHOT_MAX_MEMORY_SAMPLES, DEVTOOLS_SNAPSHOT_MAX_NETWORK_ENTRIES,
+};
 
 pub use flutter_controller::{
     CommandSenderController, DaemonFlutterController, FlutterCommand, FlutterController,

--- a/crates/fdemon-app/src/services/state_service.rs
+++ b/crates/fdemon-app/src/services/state_service.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Duration, Local};
 use tokio::sync::{broadcast, RwLock};
 
+use super::devtools_service::{DevToolsSessionSnapshot, WidgetTreeSnapshot};
 use super::session_service::SessionSnapshot;
 use fdemon_core::{AppPhase, DaemonMessage, DeviceInfo, LogEntry};
 
@@ -82,6 +83,14 @@ pub struct SharedState {
     /// Snapshots of all active sessions (synced from the SessionManager)
     pub sessions: Arc<RwLock<Vec<SessionSnapshot>>>,
 
+    /// Per-session DevTools telemetry snapshots (frames, memory, network),
+    /// synced from the per-session ring buffers each TEA cycle.
+    pub devtools: Arc<RwLock<Vec<DevToolsSessionSnapshot>>>,
+
+    /// Cached widget tree for the currently selected session, synced from the
+    /// inspector view-state. `None` when no session is selected.
+    pub widget_tree: Arc<RwLock<Option<WidgetTreeSnapshot>>>,
+
     /// Event broadcaster for multiple subscribers
     pub event_tx: broadcast::Sender<DaemonMessage>,
 
@@ -98,6 +107,8 @@ impl SharedState {
             logs: Arc::new(RwLock::new(Vec::new())),
             devices: Arc::new(RwLock::new(Vec::new())),
             sessions: Arc::new(RwLock::new(Vec::new())),
+            devtools: Arc::new(RwLock::new(Vec::new())),
+            widget_tree: Arc::new(RwLock::new(None)),
             event_tx,
             max_logs,
         }

--- a/crates/fdemon-app/src/session/handle.rs
+++ b/crates/fdemon-app/src/session/handle.rs
@@ -215,6 +215,21 @@ pub struct SessionHandle {
     /// for the session's lifetime.
     pub rebuilt_widgets_gate_tx: Option<Arc<tokio::sync::watch::Sender<bool>>>,
 
+    /// Whether a service-layer consumer (e.g. an MCP server embedding the
+    /// Engine) has requested continuous DevTools telemetry for this session.
+    ///
+    /// Set by `Message::StartDevToolsMonitoring`, cleared by
+    /// `Message::StopDevToolsMonitoring`. While `true`:
+    /// - The TUI's pause-on-DevTools-exit paths skip pausing the performance
+    ///   and network polling loops, so headless consumers keep receiving
+    ///   memory samples and HTTP profile entries.
+    /// - `VmServiceConnected` starts performance/network monitoring even when
+    ///   the TUI is not in DevTools mode.
+    ///
+    /// Survives VM reconnects (it lives on the handle, not the session
+    /// telemetry state, which is reset on reconnect).
+    pub devtools_service_monitoring: bool,
+
     /// Per-session native log tag discovery and visibility state.
     ///
     /// Tracks every distinct tag seen in this session's native log stream
@@ -265,6 +280,10 @@ impl std::fmt::Debug for SessionHandle {
                 "has_rebuilt_widgets_gate",
                 &self.rebuilt_widgets_gate_tx.is_some(),
             )
+            .field(
+                "devtools_service_monitoring",
+                &self.devtools_service_monitoring,
+            )
             .field("native_tag_count", &self.native_tag_state.tag_count())
             .field("custom_source_count", &self.custom_source_handles.len())
             .finish()
@@ -296,6 +315,7 @@ impl SessionHandle {
             timeline_pause_tx: None,
             timeline_task_handle: None,
             rebuilt_widgets_gate_tx: None,
+            devtools_service_monitoring: false,
             native_tag_state: NativeTagState::default(),
             custom_source_handles: Vec::new(),
         }

--- a/crates/fdemon-app/src/state.rs
+++ b/crates/fdemon-app/src/state.rs
@@ -1302,6 +1302,50 @@ impl Toast {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Embedder status badge
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Visual category of an embedder [`StatusBadge`].
+///
+/// Controls the accent colour the TUI uses when rendering the badge in the
+/// main header; it carries no semantics beyond presentation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusBadgeKind {
+    /// Neutral informational badge (muted accent).
+    Info,
+    /// Something is actively running/connected (green accent).
+    Active,
+    /// Something needs attention (yellow accent).
+    Warn,
+}
+
+/// A small, generic status indicator supplied by an external embedder.
+///
+/// Embedders (e.g. an MCP server wrapping the Engine) set this via
+/// [`crate::message::Message::SetStatusBadge`] to surface their own state in
+/// the TUI — for example `"MCP 2 clients"`. fdemon itself never sets a badge;
+/// the slot is intentionally embedder-agnostic. The TUI renders the badge near
+/// the right edge of the main header and renders nothing when the slot is
+/// `None`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusBadge {
+    /// Short human-readable label (keep it brief — it shares the header row).
+    pub text: String,
+    /// Visual category (controls accent colour).
+    pub kind: StatusBadgeKind,
+}
+
+impl StatusBadge {
+    /// Construct a new badge.
+    pub fn new(text: impl Into<String>, kind: StatusBadgeKind) -> Self {
+        Self {
+            text: text.into(),
+            kind,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 /// Complete application state (the Model in TEA)
 #[derive(Debug)]
 pub struct AppState {
@@ -1454,6 +1498,13 @@ pub struct AppState {
     /// `handler/devtools/mod.rs`) via [`AppState::push_toast`].
     /// Expired automatically on each `Tick` via [`AppState::expire_toasts`].
     pub toasts: Vec<Toast>,
+
+    /// Generic embedder status badge shown near the right edge of the main
+    /// header (e.g. `"MCP 2 clients"` from an MCP server embedding the Engine).
+    ///
+    /// Set/cleared by [`crate::message::Message::SetStatusBadge`]; `None`
+    /// (the default) renders nothing and leaves the header layout untouched.
+    pub status_badge: Option<StatusBadge>,
 
     /// Per-frame mouse click-region registry.
     ///
@@ -1610,6 +1661,7 @@ impl AppState {
             install_wizard_state: InstallWizardState::default(),
             startup_notice: None,
             toasts: Vec::new(),
+            status_badge: None,
             mouse_regions: MouseRegionsCell::new(MouseRegions::with_capacity()),
             last_log_click: None,
             last_settings_click: None,

--- a/crates/fdemon-tui/src/render/mod.rs
+++ b/crates/fdemon-tui/src/render/mod.rs
@@ -242,7 +242,8 @@ pub fn view(frame: &mut Frame, state: &mut AppState) {
         .unwrap_or(0.0);
     let header = widgets::MainHeader::new(state.project_name.as_deref(), icons)
         .with_sessions(&state.session_manager)
-        .reload_flash(reload_flash);
+        .reload_flash(reload_flash)
+        .status_badge(state.status_badge.as_ref());
     let header_ctx: Option<&mut MouseCtx<'_>> = if in_modal { None } else { Some(&mut mouse_ctx) };
     widgets::header::render_main_header(areas.header, frame.buffer_mut(), &header, header_ctx);
 

--- a/crates/fdemon-tui/src/widgets/header.rs
+++ b/crates/fdemon-tui/src/widgets/header.rs
@@ -11,7 +11,7 @@ use ratatui::{
 };
 
 use fdemon_app::session_manager::SessionManager;
-use fdemon_app::{Message, MouseAction, MouseRect};
+use fdemon_app::{Message, MouseAction, MouseRect, StatusBadge, StatusBadgeKind};
 
 use crate::theme::{branding, icons::IconSet, palette, styles};
 use crate::widgets::MouseCtx;
@@ -41,6 +41,10 @@ pub struct MainHeader<'a> {
     /// `0.0` = no tint (steady state); `1.0` = peak blend at completion.
     /// Set via `.reload_flash(..)` builder.
     reload_flash: f32,
+    /// Optional embedder status badge rendered at the right edge of the title
+    /// row (e.g. `"MCP 2 clients"`). Set via `.status_badge(..)` builder;
+    /// `None` (the default) renders nothing and changes no layout.
+    status_badge: Option<&'a StatusBadge>,
 }
 
 impl<'a> MainHeader<'a> {
@@ -50,12 +54,20 @@ impl<'a> MainHeader<'a> {
             session_manager: None,
             icons,
             reload_flash: 0.0,
+            status_badge: None,
         }
     }
 
     /// Add session manager to render tabs inside the header
     pub fn with_sessions(mut self, session_manager: &'a SessionManager) -> Self {
         self.session_manager = Some(session_manager);
+        self
+    }
+
+    /// Show a generic embedder status badge near the right edge of the title
+    /// row. `None` leaves the header exactly as it renders without a badge.
+    pub fn status_badge(mut self, badge: Option<&'a StatusBadge>) -> Self {
+        self.status_badge = badge;
         self
     }
 
@@ -351,9 +363,33 @@ impl MainHeader<'_> {
             .map(|l| l.width() as u16)
             .unwrap_or(0);
 
+        // Build embedder status badge (rightmost section), if set.
+        let badge_content = self.status_badge.map(|badge| {
+            let color = match badge.kind {
+                StatusBadgeKind::Info => palette::ACCENT,
+                StatusBadgeKind::Active => palette::STATUS_GREEN,
+                StatusBadgeKind::Warn => palette::STATUS_YELLOW,
+            };
+            Line::from(vec![
+                Span::styled(self.icons.circle(), Style::default().fg(color)),
+                Span::raw(" "),
+                Span::styled(badge.text.clone(), Style::default().fg(color)),
+                Span::raw(" "),
+            ])
+        });
+        let badge_width = badge_content
+            .as_ref()
+            .map(|l| l.width() as u16)
+            .unwrap_or(0);
+        // The badge claims the rightmost cells of the row; sections that were
+        // previously right-aligned (the device pill) anchor against `badge_x`
+        // instead of the area edge. With no badge, `badge_x` equals the right
+        // edge, so the layout is byte-for-byte identical to before.
+        let badge_x = (area.x + area.width).saturating_sub(badge_width);
+
         // Calculate available space and positioning
         let total_content_width =
-            left_width + shortcuts_width + device_width + HEADER_SECTION_PADDING;
+            left_width + shortcuts_width + device_width + badge_width + HEADER_SECTION_PADDING;
 
         if total_content_width <= area.width {
             // Everything fits: left | center | right layout
@@ -371,19 +407,19 @@ impl MainHeader<'_> {
                 }
             }
 
-            // Right-align device pill
+            // Right-align device pill (left of the badge when one is set)
             if let Some(device_line) = device_content {
-                let device_x = area.x + area.width - device_width;
+                let device_x = badge_x.saturating_sub(device_width);
                 if device_x >= area.x + left_width + shortcuts_width + HEADER_SECTION_PADDING {
                     buf.set_line(device_x, area.y, &device_line, device_width);
                 }
             }
-        } else if left_width + device_width + 2 <= area.width {
+        } else if left_width + device_width + badge_width + 2 <= area.width {
             // Shortcuts don't fit, but left + device does — no region registration.
             buf.set_line(area.x, area.y, &left_line, area.width);
 
             if let Some(device_line) = device_content {
-                let device_x = area.x + area.width - device_width;
+                let device_x = badge_x.saturating_sub(device_width);
                 if device_x >= area.x + left_width + 2 {
                     buf.set_line(device_x, area.y, &device_line, device_width);
                 }
@@ -391,6 +427,14 @@ impl MainHeader<'_> {
         } else {
             // Only left section fits — no region registration.
             buf.set_line(area.x, area.y, &left_line, area.width);
+        }
+
+        // Paint the badge last so it can never be overdrawn by the sections
+        // above; skipped when it would collide with the left section.
+        if let Some(badge_line) = badge_content {
+            if badge_x > area.x + left_width {
+                buf.set_line(badge_x, area.y, &badge_line, badge_width);
+            }
         }
     }
 }
@@ -872,6 +916,147 @@ mod tests {
         } else {
             panic!("expected Rgb color, got {bg:?}");
         }
+    }
+
+    // ── Embedder status badge tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_header_renders_status_badge_text() {
+        let mut term = TestTerminal::with_size(120, 5);
+        let icons = IconSet::new(IconMode::Unicode);
+        let badge = StatusBadge::new("MCP 2 clients", StatusBadgeKind::Active);
+        let header = MainHeader::new(Some("test_app"), icons).status_badge(Some(&badge));
+
+        term.render_widget(header, term.area());
+
+        assert!(
+            term.buffer_contains("MCP 2 clients"),
+            "Header should render the embedder status badge text"
+        );
+        // Existing sections must still render alongside the badge.
+        assert!(term.buffer_contains("test_app"), "project name still shown");
+        assert!(term.buffer_contains("[r] Run"), "shortcuts still shown");
+    }
+
+    #[test]
+    fn test_header_without_badge_renders_nothing_extra() {
+        let mut term = TestTerminal::with_size(120, 5);
+        let icons = IconSet::new(IconMode::Unicode);
+        let header = MainHeader::new(Some("test_app"), icons).status_badge(None);
+
+        term.render_widget(header, term.area());
+
+        assert!(
+            !term.buffer_contains("MCP"),
+            "No badge text should appear when the badge slot is None"
+        );
+        assert!(term.buffer_contains("test_app"));
+        assert!(term.buffer_contains("[r] Run"));
+    }
+
+    #[test]
+    fn test_header_badge_layout_identical_when_unset() {
+        // Rendering with `.status_badge(None)` must produce exactly the same
+        // buffer as not calling the builder at all.
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+
+        let area = Rect::new(0, 0, 120, 5);
+        let icons = IconSet::new(IconMode::Unicode);
+
+        let mut buf_plain = Buffer::empty(area);
+        let header_plain = MainHeader::new(Some("app"), icons);
+        render_main_header(area, &mut buf_plain, &header_plain, None);
+
+        let mut buf_none = Buffer::empty(area);
+        let header_none = MainHeader::new(Some("app"), icons).status_badge(None);
+        render_main_header(area, &mut buf_none, &header_none, None);
+
+        assert_eq!(
+            buf_plain, buf_none,
+            "status_badge(None) must not disturb the existing layout"
+        );
+    }
+
+    #[test]
+    fn test_header_badge_renders_in_multi_session_mode() {
+        let mut term = TestTerminal::with_size(120, 5);
+        let mut session_manager = SessionManager::new();
+        session_manager
+            .create_session(&test_device_with_platform("d1", "iPhone 15", "ios"))
+            .unwrap();
+        session_manager
+            .create_session(&test_device_with_platform("d2", "Pixel 7", "android"))
+            .unwrap();
+
+        let icons = IconSet::new(IconMode::Unicode);
+        let badge = StatusBadge::new("MCP 2 clients", StatusBadgeKind::Info);
+        let header = MainHeader::new(Some("test_app"), icons)
+            .with_sessions(&session_manager)
+            .status_badge(Some(&badge));
+
+        term.render_widget(header, term.area());
+
+        assert!(
+            term.buffer_contains("MCP 2 clients"),
+            "badge should render on the title row in multi-session mode"
+        );
+        assert!(term.buffer_contains("iPhone 15"), "tabs still render");
+    }
+
+    #[test]
+    fn test_header_badge_kind_controls_color() {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+
+        // Render a badge and find the foreground color of its first text cell.
+        fn badge_text_fg(kind: StatusBadgeKind) -> ratatui::style::Color {
+            let area = Rect::new(0, 0, 120, 5);
+            let mut buf = Buffer::empty(area);
+            let icons = IconSet::new(IconMode::Unicode);
+            let badge = StatusBadge::new("BADGE", kind);
+            let header = MainHeader::new(Some("app"), icons).status_badge(Some(&badge));
+            render_main_header(area, &mut buf, &header, None);
+
+            // Title row is y=1 (inside the border). Find the 'B' of "BADGE"
+            // near the right edge.
+            let row = 1u16;
+            for x in (0..area.width).rev() {
+                if buf[(x, row)].symbol() == "B" {
+                    return buf[(x, row)]
+                        .style()
+                        .fg
+                        .unwrap_or(ratatui::style::Color::Reset);
+                }
+            }
+            panic!("badge text not found in buffer");
+        }
+
+        assert_eq!(badge_text_fg(StatusBadgeKind::Info), palette::ACCENT);
+        assert_eq!(
+            badge_text_fg(StatusBadgeKind::Active),
+            palette::STATUS_GREEN
+        );
+        assert_eq!(badge_text_fg(StatusBadgeKind::Warn), palette::STATUS_YELLOW);
+    }
+
+    #[test]
+    fn test_header_badge_skipped_when_no_room() {
+        // At a very narrow width, the badge would collide with the left
+        // section and must be skipped without panicking.
+        let mut term = TestTerminal::with_size(30, 5);
+        let icons = IconSet::new(IconMode::Unicode);
+        let badge = StatusBadge::new("MCP 2 clients", StatusBadgeKind::Warn);
+        let header = MainHeader::new(Some("a_long_project_name"), icons).status_badge(Some(&badge));
+
+        term.render_widget(header, term.area());
+
+        // Should render without panic; the title is still present.
+        assert!(
+            term.buffer_contains(crate::theme::branding::APP_TITLE)
+                || term.buffer_contains("Flutter"),
+            "left section should still render at narrow widths"
+        );
     }
 
     // ── Multi-session separator tests (Phase 7, Task 01) ─────────────────────


### PR DESCRIPTION
Lets external embedders (the pro MCP server) give AI agents full diagnosis of running Flutter apps through the service layer, plus a pro-agnostic status indicator in the TUI. Everything additive; no public signature changes.

**DevToolsService** (follows the `SessionService` pattern: SharedState snapshot sync + message dispatch + Engine accessor):
- Per-session snapshots: frame timings + jank stats (already collected passively), memory samples, network requests — bounded caps (300/120/100), Arc-reuse for unchanged widget trees
- Collection-gating findings, designed around: memory polling only ran in DevTools mode and network polling only with the Network panel open — new additive `Start/StopDevToolsMonitoring` messages drive the same monitoring tasks headlessly, auto-restart on VM reconnect, and suppress the TUI's pause-on-exit while embedder monitoring is active
- `fetch_widget_tree(session_id, timeout)`: dispatch-and-await honoring the existing 2s debounce; documented contract (selected session, connected VM, debug mode)

**Status badge**: `AppState::status_badge` via additive `Message::SetStatusBadge`, rendered at the right edge of the main header title row — buffer-identical when unset (verified by test), kind-styled (Info/Active/Warn). Generic: an embedder can surface "MCP:2" or anything else without upstream knowing about pro features.

36 new tests (monitoring handlers, service reads/dispatch/fetch, engine sync, badge handling + header rendering). Full workspace green: 7,640 tests, clippy `-D warnings`, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)